### PR TITLE
Binary size provider fixes

### DIFF
--- a/MeasurementApp.xcodeproj/project.pbxproj
+++ b/MeasurementApp.xcodeproj/project.pbxproj
@@ -7,13 +7,30 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		ED2B733125C627A60088B5A1 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2B732F25C627A50088B5A1 /* Accelerate.framework */; };
+		ED2B733225C627A60088B5A1 /* Accelerate.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = ED2B732F25C627A50088B5A1 /* Accelerate.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ED39101A2598F6B60059494D /* MeasurementApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3910192598F6B60059494D /* MeasurementApp.swift */; };
 		ED39101C2598F6B60059494D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED39101B2598F6B60059494D /* ContentView.swift */; };
 		ED39101E2598F6B70059494D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED39101D2598F6B70059494D /* Assets.xcassets */; };
 		ED3910212598F6B70059494D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED3910202598F6B70059494D /* Preview Assets.xcassets */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		ED2B733325C627A60088B5A1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				ED2B733225C627A60088B5A1 /* Accelerate.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		ED2B732F25C627A50088B5A1 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		ED3910162598F6B60059494D /* MeasurementApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MeasurementApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED3910192598F6B60059494D /* MeasurementApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementApp.swift; sourceTree = "<group>"; };
 		ED39101B2598F6B60059494D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -27,17 +44,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED2B733125C627A60088B5A1 /* Accelerate.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		ED2B732E25C627A50088B5A1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED2B732F25C627A50088B5A1 /* Accelerate.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		ED39100D2598F6B60059494D = {
 			isa = PBXGroup;
 			children = (
 				ED3910182598F6B60059494D /* MeasurementApp */,
 				ED3910172598F6B60059494D /* Products */,
+				ED2B732E25C627A50088B5A1 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -79,6 +106,7 @@
 				ED3910122598F6B60059494D /* Sources */,
 				ED3910132598F6B60059494D /* Frameworks */,
 				ED3910142598F6B60059494D /* Resources */,
+				ED2B733325C627A60088B5A1 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
+++ b/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
@@ -16,18 +16,31 @@ enum BinarySizeProviderError: LocalizedError, Equatable {
     case unexpectedError
 
     var errorDescription: String? {
+        let step: String
+        let message: String
         switch self {
             case let .unableToGenerateArchive(errorMessage):
-                return "Failed to generate archive with error: \(errorMessage)"
+                step = "Archiving"
+                message = errorMessage
             case let .unableToCloneEmptyApp(errorMessage):
-                return "Failed to clone empty app with error: \(errorMessage)"
+                step = "Cloning empty app"
+                message = errorMessage
             case let .unableToGetBinarySizeOnDisk(underlyingError):
-                return "Failed to get archive size with error: \(underlyingError.localizedDescription)"
+                step = "Reading binary size"
+                message = "Failed to read binary size from archive. Details: \(underlyingError.localizedDescription)"
             case let .unableToRetrieveAppProject(path):
-                return "Failed to get MeasurementApp project from XcodeProj at path: \(path)"
+                step = "Read measurement app project"
+                message = "Failed to get MeasurementApp project from XcodeProj at path: \(path)"
             case .unexpectedError:
-                return "Unexpected failure to calculate binary size. Please run with --verbose enabled for more details."
+                step = "Undefined"
+                message = "Unexpected failure. Please run with --verbose enabled for more details."
         }
+
+        return """
+        Failed to measure binary size
+        Step: \(step)
+        Error: \(message)
+        """
     }
 }
 

--- a/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
+++ b/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
@@ -40,8 +40,15 @@ public struct BinarySizeProvider {
         let sizeMeasurer = SizeMeasurer(verbose: verbose)
         var formattedPackageBinarySize: String = ""
 
+        let isProductDynamicLibrary = packageContent.products
+            .first{ $0.name == swiftPackage.product }?
+            .isDynamicLibrary ?? false
+
         do {
-            formattedPackageBinarySize = try sizeMeasurer.formattedBinarySize(for: swiftPackage)
+            formattedPackageBinarySize = try sizeMeasurer.formattedBinarySize(
+                for: swiftPackage,
+                isDynamic: isProductDynamicLibrary
+            )
         } catch let error as LocalizedError {
             return .failure(
                 .init(localizedError: error)

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -23,8 +23,9 @@ public struct PackageContent: Decodable, Equatable {
     public struct Product: Decodable, Equatable {
         public enum Kind: Equatable {
             public enum LibraryKind: String, Decodable {
-                case dynamic = "automatic"
+                case dynamic
                 case `static`
+                case automatic
             }
 
             case executable

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -156,3 +156,10 @@ public extension PackageContent.Target.Dependency {
         return names.first
     }
 }
+
+public extension PackageContent.Product {
+    var isDynamicLibrary: Bool {
+        guard case let .library(libraryKind) = self.kind else { return false }
+        return libraryKind == .dynamic
+    }
+}

--- a/Sources/Run/Subcommands/BinarySize.swift
+++ b/Sources/Run/Subcommands/BinarySize.swift
@@ -13,7 +13,7 @@ import Reports
 extension SwiftPackageInfo {
     public struct BinarySize: ParsableCommand {
         static let estimatedSizeNote = """
-        * Note: The estimated size doesn't consider optimizations such as app thinning.
+        * Note: The estimated size may not reflect the exact amount since it doesn't account optimizations such as app thinning.
         Its methodology is inspired by [cocoapods-size](https://github.com/google/cocoapods-size),
         and thus works by comparing archives with no bitcode and ARM64 arch.
         Such a strategy has proven to be very consistent with the size added to iOS apps downloaded and installed via TestFlight.

--- a/Sources/Run/Subcommands/FullAnalyzes.swift
+++ b/Sources/Run/Subcommands/FullAnalyzes.swift
@@ -38,8 +38,11 @@ extension SwiftPackageInfo {
 
             let report = Report(swiftPackage: swiftPackage)
 
-            // Providers have a synchronous API and are run in sequence. Each of them, even when performing async tasks, have to fulfill a sync API,
-            // since generally the terminal is updated with logs of the current operation.
+            // Providers have a synchronous API and are run in sequence. Each of them, even when performing async tasks, have to fulfill a sync API.
+            // For current setup it works as wanted, since the only heavy provider is binary size, that executes xcodebuild commands that are logged into the console
+            // when verbose flag is passed in. All other providers have sync logic that consumes PackageContent (Package.swift) decoded and provide specific
+            // information over it.
+            // Adding providers with asynchronous tasks should be avoided, and in case of adding any appears, things can be re-evaluated to run providers concurrently.
             var providedInfos: [ProvidedInfo] = []
             SwiftPackageInfo.subcommandsProviders.forEach { subcommandProvider in
                 subcommandProvider(

--- a/Tests/AppTests/Providers/BinarySizeProviders/BinarySizeProviderErrorTests.swift
+++ b/Tests/AppTests/Providers/BinarySizeProviders/BinarySizeProviderErrorTests.swift
@@ -1,0 +1,75 @@
+//
+//  BinarySizeProviderErrorTests.swift
+//
+//
+//  Created by Marino Felipe on 31.01.20.
+//
+
+import XCTest
+@testable import App
+
+final class BinarySizeProviderTests: XCTestCase {
+    func testUnableToGenerateArchiveLocalizedMessage() {
+        let error = BinarySizeProviderError.unableToGenerateArchive(errorMessage: "some")
+        XCTAssertEqual(
+            error.localizedDescription,
+            """
+            Failed to measure binary size
+            Step: Archiving
+            Error: some
+            """
+        )
+    }
+
+    func testUnableToCloneEmptyAppLocalizedMessage() {
+        let error = BinarySizeProviderError.unableToCloneEmptyApp(errorMessage: "some")
+        XCTAssertEqual(
+            error.localizedDescription,
+            """
+            Failed to measure binary size
+            Step: Cloning empty app
+            Error: some
+            """
+        )
+    }
+
+    func testUnableToGetBinarySizeOnDiskLocalizedMessage() {
+        let error = BinarySizeProviderError.unableToGetBinarySizeOnDisk(underlyingError: FakeError() as NSError)
+        XCTAssertEqual(
+            error.localizedDescription,
+            """
+            Failed to measure binary size
+            Step: Reading binary size
+            Error: Failed to read binary size from archive. Details: some
+            """
+        )
+    }
+
+    func testUnableToRetrieveAppProjectLocalizedMessage() {
+        let error = BinarySizeProviderError.unableToRetrieveAppProject(atPath: "path")
+        XCTAssertEqual(
+            error.localizedDescription,
+            """
+            Failed to measure binary size
+            Step: Read measurement app project
+            Error: Failed to get MeasurementApp project from XcodeProj at path: path
+            """
+        )
+    }
+
+    func testUnexpectedErrorLocalizedMessage() {
+        let error = BinarySizeProviderError.unexpectedError
+        XCTAssertEqual(
+            error.localizedDescription,
+            """
+            Failed to measure binary size
+            Step: Undefined
+            Error: Unexpected failure. Please run with --verbose enabled for more details.
+            """
+        )
+    }
+}
+
+private struct FakeError: LocalizedError {
+    let errorDescription: String? = "some"
+}

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -35,7 +35,7 @@ final class PackageContentTests: XCTestCase {
                         "Target1",
                         "Target2"
                     ],
-                    kind: .library(.dynamic)
+                    kind: .library(.automatic)
                 ),
                 .init(
                     name: "Product2",
@@ -51,6 +51,13 @@ final class PackageContentTests: XCTestCase {
                         "Target2"
                     ],
                     kind: .executable
+                ),
+                .init(
+                    name: "Product4",
+                    targets: [
+                        "Target1"
+                    ],
+                    kind: .library(.dynamic)
                 )
             ],
             dependencies: [

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -108,4 +108,59 @@ final class PackageContentTests: XCTestCase {
             expectedPackageContent
         )
     }
+
+    func testIsDynamicLibrary() throws {
+        let fixturePackageContent = PackageContent(
+            name: "SomePackage",
+            platforms: [
+                .init(
+                    platformName: "ios",
+                    version: "9.0"
+                ),
+                .init(
+                    platformName: "macos",
+                    version: "10.15"
+                )
+            ],
+            products: [
+                .init(
+                    name: "Product1",
+                    targets: [
+                        "Target1",
+                        "Target2"
+                    ],
+                    kind: .library(.automatic)
+                ),
+                .init(
+                    name: "Product2",
+                    targets: [
+                        "Target1",
+                        "Target3"
+                    ],
+                    kind: .library(.static)
+                ),
+                .init(
+                    name: "Product3",
+                    targets: [
+                        "Target2"
+                    ],
+                    kind: .executable
+                ),
+                .init(
+                    name: "Product4",
+                    targets: [
+                        "Target1"
+                    ],
+                    kind: .library(.dynamic)
+                )
+            ],
+            dependencies: [],
+            targets: [],
+            swiftLanguageVersions: []
+        )
+
+        fixturePackageContent.products.forEach { product in
+            XCTAssertEqual(product.isDynamicLibrary, product == fixturePackageContent.products.last)
+        }
+    }
 }

--- a/Tests/CoreTests/Resources/package_full.json
+++ b/Tests/CoreTests/Resources/package_full.json
@@ -66,6 +66,17 @@
       "type" : {
         "executable" : null
       }
+    },
+    {
+      "name" : "Product4",
+      "targets" : [
+        "Target1"
+      ],
+      "type" : {
+        "library" : [
+          "dynamic"
+        ]
+      }
     }
   ],
   "providers" : null,


### PR DESCRIPTION
- Fix decoding `Package.swift` when `products.type` is automatic.
- Fix measuring binary size of dynamic libraries. To do that an embedded framework was added to the empty Measurement project (which also adds a `PBXCopyFilesBuildPhase` for _Embed Frameworks_), and dynamic library product are also embedded into the project target before measuring its size.
- Improve localized error messages