### PR TITLE
Normalize package version before adding it to project on binary size provider

### DIFF
--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -156,7 +156,12 @@ private extension PBXProject {
         try addSwiftPackage(
             repositoryURL: swiftPackage.repositoryURL.absoluteString,
             productName: swiftPackage.product,
-            versionRequirement: .upToNextMinorVersion(swiftPackage.version),
+            versionRequirement: .upToNextMinorVersion(
+                swiftPackage.version
+                    .trimmingCharacters(
+                        in: CharacterSet.decimalDigits.inverted
+                    )
+            ),
             targetName: targetName
         )
     }

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -7,7 +7,6 @@
 
 import ArgumentParser
 import struct Foundation.URL
-import struct TSCUtility.Version
 import Core
 import App
 import Reports
@@ -63,7 +62,7 @@ struct AllArguments: ParsableArguments {
         ],
         help: "Semantic version of the Swift Package. If not passed in the latest release is used."
     )
-    var packageVersion: Version?
+    var packageVersion: String?
 
     @Option(
         name: [
@@ -101,7 +100,7 @@ extension ParsableCommand {
     func makeSwiftPackage(from arguments: AllArguments) -> SwiftPackage {
         .init(
             repositoryURL: arguments.repositoryURL,
-            version: arguments.packageVersion?.description ?? "Undefined",
+            version: arguments.packageVersion ?? "Undefined",
             product: arguments.product
         )
     }


### PR DESCRIPTION
- Normalize package version before adding it to project on binary size provider
   - This fixes the binary size report for edge cases such as:
   ```
   swift-package-info --for https://github.com/stleamist/BetterSafariView --product BetterSafariView --package-version v2.0.0
   ```
- Also, update `--package-version` argument to a `Optional<String>` since not necessarily a version needs to match a typed semantic version (e.g. TSCUtility.Version).