### PR TITLE
Some general bug fixes

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-package-info.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-package-info.xcscheme
@@ -159,7 +159,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
-      useCustomWorkingDirectory = "NO"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "/Users/marino.felipe/Documents/projects/personal/swift-package-info"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -176,15 +177,15 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--for https://github.com/ReactiveX/RxSwift"
+            argument = "--for https://github.com/firebase/firebase-ios-sdk"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-v 6.0.0"
+            argument = "-v 7.6.0"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--product RxSwift"
+            argument = "--product FirebaseCrashlytics"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-package-info.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-package-info.xcscheme
@@ -159,8 +159,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
-      useCustomWorkingDirectory = "YES"
-      customWorkingDirectory = "/Users/marino.felipe/Documents/projects/personal/swift-package-info"
+      useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -177,15 +176,15 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--for https://github.com/firebase/firebase-ios-sdk"
+            argument = "--for https://github.com/ReactiveX/RxSwift"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-v 7.6.0"
+            argument = "-v 6.0.0"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--product FirebaseCrashlytics"
+            argument = "--product RxSwift"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Package.swift
+++ b/Package.swift
@@ -94,7 +94,8 @@ let package = Package(
             ],
             resources: [
                 .copy("Resources/package_full.json"),
-                .copy("Resources/package_with_multiple_dependencies.json")
+                .copy("Resources/package_with_multiple_dependencies.json"),
+                .copy("Resources/package_with_custom_target_dependency.json")
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -93,7 +93,8 @@ let package = Package(
                 .target(name: "TestSupport")
             ],
             resources: [
-                .copy("Resources/package_full.json")
+                .copy("Resources/package_full.json"),
+                .copy("Resources/package_with_multiple_dependencies.json")
             ]
         ),
         .target(

--- a/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
+++ b/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
@@ -51,7 +51,7 @@ public struct DependenciesProvider {
             messages = externalDependencies.map { dependency -> [ConsoleMessage] in
                 var messages: [ConsoleMessage] = [
                     .init(
-                        text: "\(dependency.name) ",
+                        text: "\(dependency.name)",
                         hasLineBreakAfter: false
                     ),
                     .init(
@@ -101,8 +101,14 @@ public struct DependenciesProvider {
         let externalDependenciesNames = targetDependencies.compactMap(\.product)
         let potentialExternalDependenciesNames = targetDependencies.compactMap(\.byName)
 
-        let otherTargetsDependenciesNames = targetDependencies.compactMap(\.target)
+        let allTargetsNames = packageContent.targets.map(\.name)
+
+        var otherTargetsDependenciesNames = targetDependencies.compactMap(\.target)
+        otherTargetsDependenciesNames += potentialExternalDependenciesNames.filter { allTargetsNames.contains($0) }
+
         var externalDependenciesFromOtherTargets: [PackageContent.Dependency] = []
+
+
         if otherTargetsDependenciesNames.isEmpty == false {
             externalDependenciesFromOtherTargets = getExternalDependencies(
                 forTargetNames: otherTargetsDependenciesNames,
@@ -111,8 +117,8 @@ public struct DependenciesProvider {
         }
 
         let externalDependencies = packageContent.dependencies.filter {
-            externalDependenciesNames.contains($0.name) ||
-                potentialExternalDependenciesNames.contains($0.name)
+            externalDependenciesNames.contains($0.name)
+                || potentialExternalDependenciesNames.contains($0.name)
         }
 
         return externalDependencies + externalDependenciesFromOtherTargets

--- a/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
+++ b/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
@@ -55,7 +55,7 @@ public struct DependenciesProvider {
                         hasLineBreakAfter: false
                     ),
                     .init(
-                        text: "v. \(dependency.requirement.range.first?.lowerBound ?? "")",
+                        text: " v. \(dependency.requirement.range.first?.lowerBound ?? "")",
                         hasLineBreakAfter: false
                     )
                 ]
@@ -102,13 +102,11 @@ public struct DependenciesProvider {
         let potentialExternalDependenciesNames = targetDependencies.compactMap(\.byName)
 
         let allTargetsNames = packageContent.targets.map(\.name)
-
         var otherTargetsDependenciesNames = targetDependencies.compactMap(\.target)
-        otherTargetsDependenciesNames += potentialExternalDependenciesNames.filter { allTargetsNames.contains($0) }
+        otherTargetsDependenciesNames += potentialExternalDependenciesNames
+            .filter { allTargetsNames.contains($0) }
 
         var externalDependenciesFromOtherTargets: [PackageContent.Dependency] = []
-
-
         if otherTargetsDependenciesNames.isEmpty == false {
             externalDependenciesFromOtherTargets = getExternalDependencies(
                 forTargetNames: otherTargetsDependenciesNames,
@@ -121,6 +119,9 @@ public struct DependenciesProvider {
                 || potentialExternalDependenciesNames.contains($0.name)
         }
 
-        return externalDependencies + externalDependenciesFromOtherTargets
+        let allDependencies = externalDependencies + externalDependenciesFromOtherTargets
+
+        return Array(Set(allDependencies))
+            .sorted(by: { $0.name < $1.name })
     }
 }

--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -81,8 +81,14 @@ public final class SwiftPackageService {
             .path("/repos/\(swiftPackage.accountName)/\(swiftPackage.repositoryName)/tags")
             .build()
 
-        let repositoryRequestPublisher: AnyPublisher<HTTPResponse<EmptyBody, EmptyBody>, HTTPResponseError> = httpClient.run(repositoryRequest, receiveOn: .global(qos: .userInteractive))
-        let tagsRequestPublisher: AnyPublisher<HTTPResponse<TagsResponse, EmptyBody>, HTTPResponseError> = httpClient.run(tagsRequest, receiveOn: .global(qos: .userInteractive))
+        let repositoryRequestPublisher: AnyPublisher<
+            HTTPResponse<EmptyBody, EmptyBody>,
+            HTTPResponseError
+        > = httpClient.run(repositoryRequest, receiveOn: .global(qos: .userInteractive))
+        let tagsRequestPublisher: AnyPublisher<
+            HTTPResponse<TagsResponse, EmptyBody>,
+            HTTPResponseError
+        > = httpClient.run(tagsRequest, receiveOn: .global(qos: .userInteractive))
 
         let semaphore = DispatchSemaphore(value: 0)
 
@@ -126,7 +132,11 @@ public final class SwiftPackageService {
         )
     }
 
-    private func fetchPackageContent(for swiftPackage: SwiftPackage, version: String, verbose: Bool) throws -> PackageContent {
+    private func fetchPackageContent(
+        for swiftPackage: SwiftPackage,
+        version: String,
+        verbose: Bool
+    ) throws -> PackageContent {
         let repositoryTemporaryPath = "\(fileManager.temporaryDirectory.path)/\(swiftPackage.repositoryName)"
 
         if fileManager.fileExists(atPath: repositoryTemporaryPath) {

--- a/Sources/App/Services/SwiftPackageService/TagsResponse.swift
+++ b/Sources/App/Services/SwiftPackageService/TagsResponse.swift
@@ -8,6 +8,10 @@
 struct TagsResponse: Equatable {
     struct Tag: Decodable, Equatable {
         let name: String
+
+        enum CodingKeys: String, CodingKey {
+            case name = "ref"
+        }
     }
 
     let tags: [Tag]

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -186,7 +186,7 @@ public extension PackageContent.Target.Dependency {
 
     var byName: String? {
         guard case let .byName(names) = self else { return nil }
-        return names.first?.name
+        return names.last?.name
     }
 }
 

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -43,9 +43,9 @@ public struct PackageContent: Decodable, Equatable {
         }
     }
 
-    public struct Dependency: Decodable, Equatable {
-        public struct Requirement: Equatable {
-            public struct Range: Decodable, Equatable {
+    public struct Dependency: Decodable, Equatable, Hashable {
+        public struct Requirement: Equatable, Hashable {
+            public struct Range: Decodable, Equatable, Hashable {
                 public let lowerBound: Version
                 public let upperBound: Version
             }

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -88,6 +88,7 @@ public struct PackageContent: Decodable, Equatable {
         }
 
         public enum Kind: String, Decodable, Equatable {
+            case binary
             case regular
             case test
         }

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -44,13 +44,15 @@ public struct PackageContent: Decodable, Equatable {
     }
 
     public struct Dependency: Decodable, Equatable {
-        public struct Requirement: Decodable, Equatable {
+        public struct Requirement: Equatable {
             public struct Range: Decodable, Equatable {
                 public let lowerBound: Version
                 public let upperBound: Version
             }
 
             public let range: [Range]
+            public let revision: [String]
+            public let branch: [String]
         }
 
         public let name: String
@@ -161,5 +163,26 @@ public extension PackageContent.Product {
     var isDynamicLibrary: Bool {
         guard case let .library(libraryKind) = self.kind else { return false }
         return libraryKind == .dynamic
+    }
+}
+
+extension PackageContent.Dependency.Requirement: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case range
+        case revision
+        case branch
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let range = try container.decodeIfPresent([Range].self, forKey: .range)
+        self.range = range ?? []
+
+        let revision = try container.decodeIfPresent([String].self, forKey: .revision)
+        self.revision = revision ?? []
+
+        let branch = try container.decodeIfPresent([String].self, forKey: .branch)
+        self.branch = branch ?? []
     }
 }

--- a/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
+++ b/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
@@ -206,7 +206,11 @@ final class DependenciesProviderTests: XCTestCase {
                         dependencies: [
                             .byName(
                                 [
-                                    .name("dependency-1"),
+                                    .name("dependency-1")
+                                ]
+                            ),
+                            .byName(
+                                [
                                     .name("dependency-3")
                                 ]
                             )
@@ -230,7 +234,7 @@ final class DependenciesProviderTests: XCTestCase {
                         hasLineBreakAfter: false
                     ),
                     .init(
-                        text: "v. 1.0.0",
+                        text: " v. 1.0.0",
                         hasLineBreakAfter: false
                     ),
                     .init(
@@ -242,7 +246,182 @@ final class DependenciesProviderTests: XCTestCase {
                         hasLineBreakAfter: false
                     ),
                     .init(
-                        text: "v. 1.0.0",
+                        text: " v. 1.0.0",
+                        hasLineBreakAfter: false
+                    )
+                ]
+            )
+        )
+    }
+
+    func testProvidedInfoWithManyNestedAndIndirectDependencies() throws {
+        let result = DependenciesProvider.fetchInformation(
+            for: SwiftPackage(
+                repositoryURL: URL(string: "https://www.apple.com")!,
+                version: "1.0.0",
+                product: "Some"
+            ),
+            packageContent: PackageContent(
+                name: "Package",
+                platforms: [],
+                products: [
+                    .init(
+                        name: "Some",
+                        targets: [
+                            "Target1"
+                        ],
+                        kind: .library(.automatic)
+                    )
+                ],
+                dependencies: [
+                    .init(
+                        name: "dependency-1",
+                        urlString: "https://www.some.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    ),
+                    .init(
+                        name: "dependency-2",
+                        urlString: "https://www.some2.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    ),
+                    .init(
+                        name: "dependency-3",
+                        urlString: "https://www.some3.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    )
+                ],
+                targets: [
+                    .init(
+                        name: "Target1",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("dependency-1")
+                                ]
+                            ),
+                            .target(
+                                [
+                                    .name("Target2")
+                                ]
+                            ),
+                            .target(
+                                [
+                                    .name("Target3")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    ),
+                    .init(
+                        name: "Target2",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("dependency-1"),
+                                    .name("dependency-1")
+                                ]
+                            ),
+                            .product(
+                                [
+                                    .name("dependency-2"),
+                                    .name("dependency-2"),
+                                ]
+                            ),
+                            .target(
+                                [
+                                    .name("Target3")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    ),
+                    .init(
+                        name: "Target3",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("dependency-1"),
+                                    .name("dependency-1")
+                                ]
+                            ),
+                            .product(
+                                [
+                                    .name("dependency-3"),
+                                    .name("dependency-3")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    )
+                ],
+                swiftLanguageVersions: []
+            ),
+            verbose: true
+        )
+
+        let providedInfo = try result.get()
+        XCTAssertEqual(
+            providedInfo,
+            .init(
+                providerName: "Dependencies",
+                messages: [
+                    .init(
+                        text: "dependency-1",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: " v. 1.0.0",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: " | ",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: "dependency-2",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: " v. 1.0.0",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: " | ",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: "dependency-3",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: " v. 1.0.0",
                         hasLineBreakAfter: false
                     )
                 ]

--- a/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
+++ b/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
@@ -1,0 +1,252 @@
+//
+//  BinarySizeProviderErrorTests.swift
+//
+//
+//  Created by Marino Felipe on 31.01.20.
+//
+
+import XCTest
+
+@testable import App
+@testable import Core
+
+final class DependenciesProviderTests: XCTestCase {
+    /// Test behavior when a product external dependency is declared by name, without matching any declared
+    /// dependency name.
+    ///
+    /// - note: Is expected to return that there are no dependencies available, since unfortunately there's no way
+    /// to define a Target dependency when it's name doesn't match with any of available Package dependencies names.
+    func testProvidedInfoWhenHasExternalDependencyDeclaredByNameThatDoesNotMatch() throws {
+        let result = DependenciesProvider.fetchInformation(
+            for: SwiftPackage(
+                repositoryURL: URL(string: "https://www.apple.com")!,
+                version: "1.0.0",
+                product: "Some"
+            ),
+            packageContent: PackageContent(
+                name: "Package",
+                platforms: [],
+                products: [
+                    .init(
+                        name: "Some",
+                        targets: [
+                            "Target1"
+                        ],
+                        kind: .library(.automatic)
+                    )
+                ],
+                dependencies: [
+                    .init(
+                        name: "dependency-1",
+                        urlString: "https://www.some.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    ),
+                    .init(
+                        name: "dependency-2",
+                        urlString: "https://www.some2.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    )
+                ],
+                targets: [
+                    .init(
+                        name: "Target1",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("Dependency1"),
+                                    .name("Target2")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    ),
+                    .init(
+                        name: "Target2",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("Dependency1")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    )
+                ],
+                swiftLanguageVersions: []
+            ),
+            verbose: true
+        )
+
+        let providedInfo = try result.get()
+        XCTAssertEqual(
+            providedInfo,
+            .init(
+                providerName: "Dependencies",
+                messages: [
+                    .init(
+                        text: "No third-party dependencies :)",
+                        hasLineBreakAfter: false
+                    )
+                ]
+            )
+        )
+    }
+
+    func testProvidedInfo() throws {
+        let result = DependenciesProvider.fetchInformation(
+            for: SwiftPackage(
+                repositoryURL: URL(string: "https://www.apple.com")!,
+                version: "1.0.0",
+                product: "Some"
+            ),
+            packageContent: PackageContent(
+                name: "Package",
+                platforms: [],
+                products: [
+                    .init(
+                        name: "Some",
+                        targets: [
+                            "Target1"
+                        ],
+                        kind: .library(.automatic)
+                    )
+                ],
+                dependencies: [
+                    .init(
+                        name: "dependency-1",
+                        urlString: "https://www.some.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    ),
+                    .init(
+                        name: "dependency-2",
+                        urlString: "https://www.some2.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    ),
+                    .init(
+                        name: "dependency-3",
+                        urlString: "https://www.some3.com",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "1.0.0",
+                                    upperBound: "1.1.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    )
+                ],
+                targets: [
+                    .init(
+                        name: "Target1",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("dependency-1")
+                                ]
+                            ),
+                            .byName(
+                                [
+                                    .name("Target2")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    ),
+                    .init(
+                        name: "Target2",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("dependency-2")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    ),
+                    .init(
+                        name: "Target3",
+                        dependencies: [
+                            .byName(
+                                [
+                                    .name("dependency-1"),
+                                    .name("dependency-3")
+                                ]
+                            )
+                        ],
+                        kind: .regular
+                    )
+                ],
+                swiftLanguageVersions: []
+            ),
+            verbose: true
+        )
+
+        let providedInfo = try result.get()
+        XCTAssertEqual(
+            providedInfo,
+            .init(
+                providerName: "Dependencies",
+                messages: [
+                    .init(
+                        text: "dependency-1",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: "v. 1.0.0",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: " | ",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: "dependency-2",
+                        hasLineBreakAfter: false
+                    ),
+                    .init(
+                        text: "v. 1.0.0",
+                        hasLineBreakAfter: false
+                    )
+                ]
+            )
+        )
+    }
+}

--- a/Tests/AppTests/Services/SwiftPackageService/TagsResponseTests.swift
+++ b/Tests/AppTests/Services/SwiftPackageService/TagsResponseTests.swift
@@ -15,25 +15,25 @@ final class TagsResponseTests: XCTestCase {
         let jsonString = """
         [
           {
-            "name": "0.2.4",
-            "zipball_url": "https://api.github.com/repos/nerdishbynature/octokit.swift/zipball/0.2.4",
-            "tarball_url": "https://api.github.com/repos/nerdishbynature/octokit.swift/tarball/0.2.4",
-            "commit": {
-              "sha": "733f6f7ee4a86eb6c0371fb6b6a2c88b95d05fe8",
-              "url": "https://api.github.com/repos/nerdishbynature/octokit.swift/commits/733f6f7ee4a86eb6c0371fb6b6a2c88b95d05fe8"
+            "ref": "refs/tags/7.5.1",
+            "node_id": "MDM6UmVmODkwMzM1NTY6cmVmcy90YWdzLzcuNS4x",
+            "url": "https://api.github.com/repos/firebase/firebase-ios-sdk/git/refs/tags/7.5.1",
+            "object": {
+              "sha": "447cf74cc561d408bc66c0294145a624645038ac",
+              "type": "commit",
+               "url": "https://api.github.com/repos/firebase/firebase-ios-sdk/git/commits/447cf74cc561d408bc66c0294145a624645038ac"
+            }
             },
-            "node_id": "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi40"
-          },
-          {
-            "name": "0.2.3",
-            "zipball_url": "https://api.github.com/repos/nerdishbynature/octokit.swift/zipball/0.2.3",
-            "tarball_url": "https://api.github.com/repos/nerdishbynature/octokit.swift/tarball/0.2.3",
-            "commit": {
-              "sha": "786a65fec263c8308672c481175ef5980d4f2d8e",
-              "url": "https://api.github.com/repos/nerdishbynature/octokit.swift/commits/786a65fec263c8308672c481175ef5980d4f2d8e"
-            },
-            "node_id": "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi4z"
-          }
+            {
+              "ref": "refs/tags/7.6.0",
+              "node_id": "MDM6UmVmODkwMzM1NTY6cmVmcy90YWdzLzcuNi4w",
+              "url": "https://api.github.com/repos/firebase/firebase-ios-sdk/git/refs/tags/7.6.0",
+              "object": {
+                "sha": "0dd2ad1054177670dfa5bb1bbc6767e2a965095d",
+                "type": "commit",
+                "url": "https://api.github.com/repos/firebase/firebase-ios-sdk/git/commits/0dd2ad1054177670dfa5bb1bbc6767e2a965095d"
+              }
+            }
         ]
         """
 
@@ -44,8 +44,8 @@ final class TagsResponseTests: XCTestCase {
             tagsResponse,
             .init(
                 tags: [
-                    .init(name: "0.2.4"),
-                    .init(name: "0.2.3")
+                    .init(name: "refs/tags/7.5.1"),
+                    .init(name: "refs/tags/7.6.0")
                 ]
             )
         )

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -94,8 +94,17 @@ final class PackageContentTests: XCTestCase {
                 .init(
                     name: "Target3",
                     dependencies: [
-                        .product(["ArgumentParser", "swift-argument-parser"]),
-                        .target(["Target1"])
+                        .product(
+                            [
+                                "ArgumentParser",
+                                "swift-argument-parser"
+                            ]
+                        ),
+                        .target(
+                            [
+                                .byName("Target1")
+                            ]
+                        )
                     ],
                     kind: .test
                 )
@@ -213,6 +222,47 @@ final class PackageContentTests: XCTestCase {
                 )
             ],
             targets: [],
+            swiftLanguageVersions: []
+        )
+
+        XCTAssertEqual(
+            packageContent,
+            expectedPackageContent
+        )
+    }
+
+    func testWhenTargetDependencyIsOfTypeTargetWithNestedPlatforms() throws {
+        let fixtureData = try dataFromJSON(
+            named: "package_with_custom_target_dependency",
+            bundle: .module
+        )
+        let packageContent = try jsonDecoder.decode(PackageContent.self, from: fixtureData)
+
+        let expectedPackageContent = PackageContent(
+            name: "SomePackage",
+            platforms: [],
+            products: [],
+            dependencies: [],
+            targets: [
+                .init(
+                    name: "Target1",
+                    dependencies: [
+                        .target(
+                            [
+                                .byName("Target2"),
+                                .platforms(
+                                    .init(
+                                        platformNames: [
+                                            "ios"
+                                        ]
+                                    )
+                                )
+                            ]
+                        )
+                    ],
+                    kind: .regular
+                )
+            ],
             swiftLanguageVersions: []
         )
 

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -70,7 +70,9 @@ final class PackageContentTests: XCTestCase {
                                 lowerBound: "0.3.0",
                                 upperBound: "0.4.0"
                             )
-                        ]
+                        ],
+                        revision: [],
+                        branch: []
                     )
                 )
             ],
@@ -110,7 +112,7 @@ final class PackageContentTests: XCTestCase {
     }
 
     func testIsDynamicLibrary() throws {
-        let fixturePackageContent = PackageContent(
+        let packageContent = PackageContent(
             name: "SomePackage",
             platforms: [
                 .init(
@@ -159,8 +161,64 @@ final class PackageContentTests: XCTestCase {
             swiftLanguageVersions: []
         )
 
-        fixturePackageContent.products.forEach { product in
-            XCTAssertEqual(product.isDynamicLibrary, product == fixturePackageContent.products.last)
+        packageContent.products.forEach { product in
+            XCTAssertEqual(product.isDynamicLibrary, product == packageContent.products.last)
         }
+    }
+
+    func testDifferentTypesOfDependencyRequirement() throws {
+        let fixtureData = try dataFromJSON(named: "package_with_multiple_dependencies", bundle: .module)
+        let packageContent = try jsonDecoder.decode(PackageContent.self, from: fixtureData)
+
+        let expectedPackageContent = PackageContent(
+            name: "SomePackage",
+            platforms: [],
+            products: [],
+            dependencies: [
+                .init(
+                    name: "swift-argument-parser",
+                    urlString: "https://github.com/apple/swift-argument-parser",
+                    requirement: .init(
+                        range: [
+                            .init(
+                                lowerBound: "0.3.0",
+                                upperBound: "0.4.0"
+                            )
+                        ],
+                        revision: [],
+                        branch: []
+                    )
+                ),
+                .init(
+                    name: "SomeDependency",
+                    urlString: "https://github.com/someDev/some-dependency",
+                    requirement: .init(
+                        range: [],
+                        revision: [
+                            "123456CrazyHash"
+                        ],
+                        branch: []
+                    )
+                ),
+                .init(
+                    name: "SomeOtherDependency",
+                    urlString: "https://github.com/someOtherDev/some-other-dependency",
+                    requirement: .init(
+                        range: [],
+                        revision: [],
+                        branch: [
+                            "some-fork-123"
+                        ]
+                    )
+                )
+            ],
+            targets: [],
+            swiftLanguageVersions: []
+        )
+
+        XCTAssertEqual(
+            packageContent,
+            expectedPackageContent
+        )
     }
 }

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -89,7 +89,7 @@ final class PackageContentTests: XCTestCase {
                     dependencies: [
                         .byName(["Target1"])
                     ],
-                    kind: .regular
+                    kind: .binary
                 ),
                 .init(
                     name: "Target3",

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -80,14 +80,22 @@ final class PackageContentTests: XCTestCase {
                 .init(
                     name: "Target1",
                     dependencies: [
-                        .product(["swift-argument-parser"])
+                        .product(
+                            [
+                                .name("swift-argument-parser")
+                            ]
+                        )
                     ],
                     kind: .regular
                 ),
                 .init(
                     name: "Target2",
                     dependencies: [
-                        .byName(["Target1"])
+                        .byName(
+                            [
+                                .name("Target1")
+                            ]
+                        )
                     ],
                     kind: .binary
                 ),
@@ -96,13 +104,13 @@ final class PackageContentTests: XCTestCase {
                     dependencies: [
                         .product(
                             [
-                                "ArgumentParser",
-                                "swift-argument-parser"
+                                .name("ArgumentParser"),
+                                .name("swift-argument-parser")
                             ]
                         ),
                         .target(
                             [
-                                .byName("Target1")
+                                .name("Target1")
                             ]
                         )
                     ],
@@ -249,7 +257,43 @@ final class PackageContentTests: XCTestCase {
                     dependencies: [
                         .target(
                             [
-                                .byName("Target2"),
+                                .name("Target2"),
+                                .platforms(
+                                    .init(
+                                        platformNames: [
+                                            "ios"
+                                        ]
+                                    )
+                                )
+                            ]
+                        )
+                    ],
+                    kind: .regular
+                ),
+                .init(
+                    name: "Target2",
+                    dependencies: [
+                        .product(
+                            [
+                                .name("Product3"),
+                                .platforms(
+                                    .init(
+                                        platformNames: [
+                                            "ios"
+                                        ]
+                                    )
+                                )
+                            ]
+                        )
+                    ],
+                    kind: .regular
+                ),
+                .init(
+                    name: "Target3",
+                    dependencies: [
+                        .byName(
+                            [
+                                .name("Name4"),
                                 .platforms(
                                     .init(
                                         platformNames: [

--- a/Tests/CoreTests/Resources/package_full.json
+++ b/Tests/CoreTests/Resources/package_full.json
@@ -126,7 +126,7 @@
       "settings" : [
 
       ],
-      "type" : "regular"
+      "type" : "binary"
     },
     {
       "dependencies" : [

--- a/Tests/CoreTests/Resources/package_with_custom_target_dependency.json
+++ b/Tests/CoreTests/Resources/package_with_custom_target_dependency.json
@@ -1,0 +1,42 @@
+{
+  "cLanguageStandard" : null,
+  "cxxLanguageStandard" : null,
+  "dependencies" : [],
+  "name" : "SomePackage",
+  "pkgConfig" : null,
+  "platforms" : [],
+  "products" : [],
+  "providers" : null,
+  "swiftLanguageVersions" : [],
+  "targets" : [
+      {
+        "dependencies" : [
+          {
+            "target" : [
+              "Target2",
+              {
+                  "platformNames": [
+                      "ios"
+                  ]
+              }
+            ]
+          }
+        ],
+        "exclude" : [
+
+        ],
+        "name" : "Target1",
+        "path" : "Path1",
+        "resources" : [
+
+        ],
+        "settings" : [
+
+        ],
+        "type" : "regular"
+      }
+  ],
+  "toolsVersion" : {
+    "_version" : "5.0.0"
+  }
+}

--- a/Tests/CoreTests/Resources/package_with_custom_target_dependency.json
+++ b/Tests/CoreTests/Resources/package_with_custom_target_dependency.json
@@ -34,6 +34,58 @@
 
         ],
         "type" : "regular"
+      },
+      {
+        "dependencies" : [
+          {
+            "product" : [
+              "Product3",
+              {
+                  "platformNames": [
+                      "ios"
+                  ]
+              }
+            ]
+          }
+        ],
+        "exclude" : [
+
+        ],
+        "name" : "Target2",
+        "path" : "Path1",
+        "resources" : [
+
+        ],
+        "settings" : [
+
+        ],
+        "type" : "regular"
+      },
+      {
+        "dependencies" : [
+          {
+            "byName" : [
+              "Name4",
+              {
+                  "platformNames": [
+                      "ios"
+                  ]
+              }
+            ]
+          }
+        ],
+        "exclude" : [
+
+        ],
+        "name" : "Target3",
+        "path" : "Path1",
+        "resources" : [
+
+        ],
+        "settings" : [
+
+        ],
+        "type" : "regular"
       }
   ],
   "toolsVersion" : {

--- a/Tests/CoreTests/Resources/package_with_multiple_dependencies.json
+++ b/Tests/CoreTests/Resources/package_with_multiple_dependencies.json
@@ -1,0 +1,46 @@
+{
+  "cLanguageStandard" : null,
+  "cxxLanguageStandard" : null,
+  "dependencies" : [
+    {
+      "name" : "swift-argument-parser",
+      "requirement" : {
+        "range" : [
+          {
+            "lowerBound" : "0.3.0",
+            "upperBound" : "0.4.0"
+          }
+        ]
+      },
+      "url" : "https:\/\/github.com\/apple\/swift-argument-parser"
+    },
+    {
+      "name" : "SomeDependency",
+      "requirement" : {
+        "revision" : [
+            "123456CrazyHash"
+        ]
+      },
+      "url" : "https:\/\/github.com\/someDev\/some-dependency"
+    },
+    {
+      "name" : "SomeOtherDependency",
+      "requirement" : {
+        "branch" : [
+            "some-fork-123"
+        ]
+      },
+      "url" : "https:\/\/github.com\/someOtherDev\/some-other-dependency"
+    }
+  ],
+  "name" : "SomePackage",
+  "pkgConfig" : null,
+  "platforms" : [],
+  "products" : [],
+  "providers" : null,
+  "swiftLanguageVersions" : [],
+  "targets" : [],
+  "toolsVersion" : {
+    "_version" : "5.0.0"
+  }
+}

--- a/Tests/RunTests/RunTests.swift
+++ b/Tests/RunTests/RunTests.swift
@@ -21,62 +21,6 @@ final class RunTests: XCTestCase {
         )
     }
 
-    func testWithInexistentTag() throws {
-        try runToolProcessAndAssert(
-            command: "--repository-url https://github.com/ReactiveX/RxSwift --package-version 8.0.0 --product RxSwift",
-            expectedOutput: """
-            [1/7] Cloning empty app...
-            [2/7] Generating archive for empty app...
-            [3/7] Calculating binary size...
-            [4/7] Adding RxSwift as dependency...
-            [5/7] Generating archive for updated app...
-            [6/7] Calculating updated binary size...
-            [7/7] Reseting and cleaning up empty app...
-
-            """,
-            expectedError: ""
-        )
-    }
-
-    func testWithInvalidProduct() throws {
-        try runToolProcessAndAssert(
-            command: "--repository-url https://github.com/ReactiveX/RxSwift --package-version 8.0.0 --product some",
-            expectedOutput: """
-            Error: Invalid argument \'--product <product>\'
-            Usage: The product should match one of the declared products on https://github.com/ReactiveX/RxSwift.
-            Found available products: [\"RxSwift\", \"RxCocoa\", \"RxRelay\", \"RxBlocking\", \"RxTest\"].
-
-            """,
-            expectedError: ""
-        )
-    }
-
-    func testWhenAllParametersAreValid() throws {
-        try runToolProcessAndAssert(
-            command: "--repository-url https://github.com/ReactiveX/RxSwift --package-version 6.0.0 --product RxSwift",
-            expectedOutput: """
-            [1/7] Cloning empty app...
-            [2/7] Generating archive for empty app...
-            [3/7] Calculating binary size...
-            [4/7] Adding RxSwift as dependency...
-            [5/7] Generating archive for updated app...
-            [6/7] Calculating updated binary size...
-            [7/7] Reseting and cleaning up empty app...
-
-            """,
-            expectedError: ""
-        )
-    }
-
-    func testWhenVerboseFlagIsSet() throws {
-        // All values are expected to be logged via Console
-        try runToolProcessAndAssert(
-            command: "--repository-url https://github.com/ReactiveX/RxSwift --package-version 6.0.0 --product RxSwift --verbose",
-            expectedOutput: "",
-            expectedError: ""
-        )
-    }
-
     func testWithMissingParameters() throws {
         // assert when only --repository-url is passed in
         try runToolProcessAndAssert(


### PR DESCRIPTION
## Description
- Adjust and add tests to some previously unmapped cases of decoding `Package.swift`
- Properly fetch repository tags, by getting repository tags from `https://api.github.com/repos/${user-name}/{repo-name}/git/refs/tags`.
  - This is important since tags are checked against user passed in `-v` or to set a default fallback version
- Correctly report external dependencies when they are declared by name and doesn't match dumped Package.swift JSON's `dependencies.name`.

### Issues fixed
- #11 
- #9