### PR TITLE
Increase package repository clone timeout and only use temporary dir for measuring binary size

### DIFF
--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -24,7 +24,8 @@ fileprivate enum Constants {
 /// Provides API to work with the `measurement app`.
 /// Can `generate archive`, `calculate its binary size` and `mutate the project` with a given Swift Package dependency`.
 final class AppManager {
-    private lazy var appPath: String = fileManager.currentDirectoryPath
+    private lazy var appPath: String = fileManager.temporaryDirectory
+        .path
         .appending("/")
         .appending(Constants.xcodeProjPath)
 
@@ -53,6 +54,7 @@ final class AppManager {
     func cloneEmptyApp() throws {
         do {
             try Shell.performShallowGitClone(
+                workingDirectory: fileManager.temporaryDirectory.path,
                 repositoryURLString: "https://github.com/marinofelipe/swift-package-info",
                 branchOrTag: "main",
                 verbose: verbose
@@ -68,8 +70,7 @@ final class AppManager {
         archive \
         -project \(Constants.xcodeProjPath) \
         -scheme \(Constants.appName) \
-        -archivePath \(fileManager.temporaryDirectory.path)/\(Constants.archiveName) \
-        -derivedDataPath \(fileManager.temporaryDirectory.path) \
+        -archivePath \(Constants.archiveName) \
         -configuration Release \
         -arch arm64 \
         CODE_SIGNING_REQUIRED=NO \
@@ -83,6 +84,7 @@ final class AppManager {
 
         let output = try Shell.run(
             command.text,
+            workingDirectory: fileManager.temporaryDirectory.path,
             verbose: verbose,
             timeout: nil
         )
@@ -139,13 +141,6 @@ final class AppManager {
 
             try xcodeProj.write(path: .init(appPath))
         }
-    }
-
-    func cleanupClonedApp() throws {
-        try Shell.run(
-            "rm -rf swift-package-info",
-            verbose: verbose
-        )
     }
 }
 

--- a/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
+++ b/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
@@ -27,7 +27,7 @@ final class SizeMeasurer {
         self.verbose = verbose
     }
 
-    private static let stepsCount = 7
+    private static let stepsCount = 6
     private var currentStep = 1
     private static let second: Double = 1_000_000
 
@@ -37,21 +37,15 @@ final class SizeMeasurer {
     ) throws -> String {
         console.lineBreak()
 
-        do {
-            let emptyAppSize = try measureEmptyAppSize()
-            let appSizeWithDependencyAdded = try measureAppSize(
-                with: swiftPackage,
-                isDynamic: isDynamic
-            )
-            try cleanup()
+        let emptyAppSize = try measureEmptyAppSize()
+        let appSizeWithDependencyAdded = try measureAppSize(
+            with: swiftPackage,
+            isDynamic: isDynamic
+        )
 
-            let increasedSize = appSizeWithDependencyAdded.amount - emptyAppSize.amount
-            return URL.fileByteCountFormatter
-                .string(for: increasedSize) ?? "\(increasedSize)"
-        } catch {
-            try? cleanup()
-            throw error
-        }
+        let increasedSize = appSizeWithDependencyAdded.amount - emptyAppSize.amount
+        return URL.fileByteCountFormatter
+            .string(for: increasedSize) ?? "\(increasedSize)"
     }
 }
 
@@ -105,13 +99,6 @@ private extension SizeMeasurer {
         try appManager.generateArchive()
         if verbose == false { showOrUpdateLoading(withText: "Calculating updated binary size...") }
         return try appManager.calculateBinarySize()
-    }
-    
-    func cleanup() throws {
-        if verbose == false { showOrUpdateLoading(withText: "Reseting and cleaning up empty app...") }
-        try appManager.cleanupClonedApp()
-
-        completeLoading()
     }
 
     func showOrUpdateLoading(withText text: String) {

--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -150,7 +150,8 @@ public final class SwiftPackageService {
             workingDirectory: fileManager.temporaryDirectory.path,
             repositoryURLString: swiftPackage.repositoryURL.absoluteString,
             branchOrTag: version,
-            verbose: verbose
+            verbose: verbose,
+            timeout: 60
         )
         guard fetchOutput.succeeded else {
             let errorMessage = String(data: fetchOutput.errorData, encoding: .utf8) ?? ""

--- a/Sources/Core/Shell.swift
+++ b/Sources/Core/Shell.swift
@@ -72,13 +72,14 @@ public extension Shell {
         workingDirectory: String? = FileManager.default.currentDirectoryPath,
         repositoryURLString: String,
         branchOrTag: String,
-        verbose: Bool
+        verbose: Bool,
+        timeout: TimeInterval? = 5
     ) throws -> Output {
         try Shell.run(
             "git clone --branch \(branchOrTag) --depth 1 \(repositoryURLString)",
             workingDirectory: workingDirectory,
             verbose: verbose,
-            timeout: 5
+            timeout: timeout
         )
     }
 }

--- a/Sources/Core/Shell.swift
+++ b/Sources/Core/Shell.swift
@@ -73,7 +73,7 @@ public extension Shell {
         repositoryURLString: String,
         branchOrTag: String,
         verbose: Bool,
-        timeout: TimeInterval? = 5
+        timeout: TimeInterval? = 15
     ) throws -> Output {
         try Shell.run(
             "git clone --branch \(branchOrTag) --depth 1 \(repositoryURLString)",


### PR DESCRIPTION
- Increase git repository shallow clone timeout a24debd
   - it allows larger repositories to be cloned without the tool failing.

- Clone empty app into temp directory 045a08f
    - To avoid leaving dirty on user's running directory, for example when the user cancels swift-package-info in the middle of its work.