### PR TITLE
Clean EmptyApp directory if exists

### DIFF
--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -58,15 +58,6 @@ final class AppManager {
 
     func cloneEmptyApp() throws {
         do {
-            if fileManager.fileExists(atPath: emptyAppDirectoryPath) {
-                if verbose {
-                    console.lineBreakAndWrite(
-                        "Removing existing EmptyApp directory: \(emptyAppDirectoryPath)"
-                    )
-                }
-                try fileManager.removeItem(atPath: emptyAppDirectoryPath)
-            }
-
             try Shell.performShallowGitClone(
                 workingDirectory: fileManager.temporaryDirectory.path,
                 repositoryURLString: "https://github.com/marinofelipe/swift-package-info",
@@ -75,6 +66,12 @@ final class AppManager {
             )
         } catch {
             throw BinarySizeProviderError.unableToCloneEmptyApp(errorMessage: error.localizedDescription)
+        }
+    }
+
+    func cleanupEmptyAppDirectory() throws {
+        if fileManager.fileExists(atPath: emptyAppDirectoryPath) {
+            try fileManager.removeItem(atPath: emptyAppDirectoryPath)
         }
     }
 

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -29,6 +29,11 @@ final class AppManager {
         .appending("/")
         .appending(Constants.xcodeProjPath)
 
+    private lazy var emptyAppDirectoryPath: String = fileManager.temporaryDirectory
+        .path
+        .appending("/")
+        .appending(Constants.clonedRepoName)
+
     private var archivedProductPath: String {
         fileManager.temporaryDirectory
             .path
@@ -53,6 +58,15 @@ final class AppManager {
 
     func cloneEmptyApp() throws {
         do {
+            if fileManager.fileExists(atPath: emptyAppDirectoryPath) {
+                if verbose {
+                    console.lineBreakAndWrite(
+                        "Removing existing EmptyApp directory: \(emptyAppDirectoryPath)"
+                    )
+                }
+                try fileManager.removeItem(atPath: emptyAppDirectoryPath)
+            }
+
             try Shell.performShallowGitClone(
                 workingDirectory: fileManager.temporaryDirectory.path,
                 repositoryURLString: "https://github.com/marinofelipe/swift-package-info",

--- a/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
+++ b/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
@@ -27,7 +27,7 @@ final class SizeMeasurer {
         self.verbose = verbose
     }
 
-    private static let stepsCount = 6
+    private static let stepsCount = 7
     private var currentStep = 1
     private static let second: Double = 1_000_000
 
@@ -43,6 +43,7 @@ final class SizeMeasurer {
             isDynamic: isDynamic
         )
 
+        completeLoading()
         let increasedSize = appSizeWithDependencyAdded.amount - emptyAppSize.amount
         return URL.fileByteCountFormatter
             .string(for: increasedSize) ?? "\(increasedSize)"
@@ -53,6 +54,9 @@ final class SizeMeasurer {
 
 private extension SizeMeasurer {
     func measureEmptyAppSize() throws -> SizeOnDisk {
+        if verbose == false { showOrUpdateLoading(withText: "Cleaning up empty app directory...") }
+        try appManager.cleanupEmptyAppDirectory()
+
         if verbose {
             console.lineBreakAndWrite("Cloning empty app")
         } else {
@@ -75,7 +79,7 @@ private extension SizeMeasurer {
         if verbose == false { showOrUpdateLoading(withText: "Calculating binary size...") }
         return try appManager.calculateBinarySize()
     }
-    
+
     func measureAppSize(
         with swiftPackage: SwiftPackage,
         isDynamic: Bool


### PR DESCRIPTION
This is needed to not pollute results by previous runs. Resolves #17

Alternative approach:
Create empty directory for each run and clean after work is finished. This will allow run multiple `swift-package-info` instances at the same time. Not sure if it needs right now.