### PR TITLE
Correctly decode Targets of type system

### DIFF
--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -91,6 +91,7 @@ public struct PackageContent: Decodable, Equatable {
             case binary
             case regular
             case test
+            case system
         }
 
         public let name: String

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -115,6 +115,11 @@ final class PackageContentTests: XCTestCase {
                         )
                     ],
                     kind: .test
+                ),
+                .init(
+                    name: "Target4",
+                    dependencies: [],
+                    kind: .system
                 )
             ],
             swiftLanguageVersions: [

--- a/Tests/CoreTests/Resources/package_full.json
+++ b/Tests/CoreTests/Resources/package_full.json
@@ -156,6 +156,23 @@
 
       ],
       "type" : "test"
+    },
+    {
+      "dependencies" : [
+
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Target4",
+      "path" : "Path",
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "system"
     }
   ],
   "toolsVersion" : {


### PR DESCRIPTION
Fix #16 by correctly decoding targets of type system.
It was an unmapped case of dumped `Package.swift`.