### PR TITLE
Make product argument optional: use first available product by default

### DIFF
--- a/Sources/Core/Models/SwiftPackage.swift
+++ b/Sources/Core/Models/SwiftPackage.swift
@@ -10,7 +10,7 @@ import struct Foundation.URL
 public struct SwiftPackage: Equatable, CustomStringConvertible {
     public let repositoryURL: URL
     public var version: String
-    public let product: String
+    public var product: String
 
     public init(
         repositoryURL: URL,

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -129,20 +129,13 @@ extension ParsableCommand {
         }
 
         if packageResponse.isProductValid == false {
-            if let firstProduct = packageResponse.packageContent.products.first?.name,
-               swiftPackage.product == "Undefined" {
+            if let firstProduct = packageResponse.availableProducts.first {
                 Console.default.lineBreakAndWrite("Invalid product: \(swiftPackage.product)")
                 Console.default.lineBreakAndWrite("Using first found product instead: \(firstProduct)")
 
                 swiftPackage.product = firstProduct
             } else {
-                throw CleanExit.message(
-                    """
-                    Error: Invalid argument '--product <product>'
-                    Usage: The product should match one of the declared products on \(swiftPackage.repositoryURL).
-                    Found available products: \(packageResponse.availableProducts).
-                    """
-                )
+                throw CleanExit.message("Error: \(swiftPackage.repositoryURL) doesn't contain any product declared on Package.swift")
             }
         }
 

--- a/Tests/RunTests/RunTests.swift
+++ b/Tests/RunTests/RunTests.swift
@@ -21,30 +21,6 @@ final class RunTests: XCTestCase {
         )
     }
 
-    func testWithMissingParameters() throws {
-        // assert when only --repository-url is passed in
-        try runToolProcessAndAssert(
-            command: "--repository-url https://github.com/ReactiveX/RxSwift",
-            expectedOutput: "",
-            expectedError: """
-            Error: Missing expected argument \'--product <product>\'\nUsage: swift-package-info full-analyzes --repository-url <repository-url> [--package-version <package-version>] --product <product> [--verbose]
-              See \'swift-package-info full-analyzes --help\' for more information.
-
-            """
-        )
-
-        // assert when --product is missing
-        try runToolProcessAndAssert(
-            command: "--repository-url https://github.com/ReactiveX/RxSwift --package-version 6.0.0",
-            expectedOutput: "",
-            expectedError: """
-            Error: Missing expected argument \'--product <product>\'\nUsage: swift-package-info full-analyzes --repository-url <repository-url> [--package-version <package-version>] --product <product> [--verbose]
-              See \'swift-package-info full-analyzes --help\' for more information.
-
-            """
-        )
-    }
-
     func testHelp() throws {
         let expectedOutput = """
         OVERVIEW: A tool for analyzing Swift Packages


### PR DESCRIPTION
In many cases first available product is what we want, so make `--product` argument optional, just like `--packageVersion`.

`swift-package-info --for https://github.com/airbnb/lottie-ios` now works:

```
Identified Swift Package:
Repository URL: https://github.com/airbnb/lottie-ios
Version: Undefined
Product: Undefined

Invalid version: Undefined

Using latest found tag instead: 3.2.1

Invalid product: Undefined

Using first found product instead: Lottie

[6/6] Calculating updated binary size...
+------------------------------------------------+
|               Swift Package Info               |
|                                                |
|                  Lottie, 3.2.1                 |
+--------------+---------------------------------+
| Provider     | Results                         |
+--------------+---------------------------------+
| Binary Size  | Binary size increases by 807 KB |
| Platforms    | ios from v. 9.0                 |
| Dependencies | No third-party dependencies :)  |
+--------------+---------------------------------+
> Total of 3 providers used.
```