### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -21,7 +21,7 @@ public struct SwiftPackageInfo: ParsableCommand {
         that can be used in your favor when deciding whether to
         adopt or not a Swift Package as a dependency on your app.
         """,
-        version: "1.0",
+        version: "1.0.6",
         subcommands: [
             BinarySize.self,
             Platforms.self,


### PR DESCRIPTION
`swift-package-info --version` now prints 1.0 which a bit outdated 🙂

Updated to 1.0.6 – upcoming release I hope.