### PR TITLE
Fix local package logic

### DIFF
--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -191,7 +191,8 @@ private extension PBXProject {
         targetName: String = Constants.appName
     ) throws -> XCSwiftPackageProductDependency {
         try addLocalSwiftPackage(
-            path: .init(swiftPackage.url.path),
+            // Relative path is adjusted for the location of the cloned MeasurementApp
+            path: .init("../\(swiftPackage.url.path)"),
             productName: swiftPackage.product,
             targetName: targetName
         )

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -124,7 +124,9 @@ final class AppManager {
 
             return appSize
         } catch {
-            throw BinarySizeProviderError.unableToGetBinarySizeOnDisk(underlyingError: error as NSError)
+            throw BinarySizeProviderError.unableToGetBinarySizeOnDisk(
+                underlyingError: error as NSError
+            )
         }
     }
 

--- a/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
+++ b/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
@@ -31,6 +31,10 @@ final class SizeMeasurer {
     private var currentStep = 1
     private static let second: Double = 1_000_000
 
+    deinit {
+        try? appManager.cleanUp()
+    }
+
     public func formattedBinarySize(
         for swiftPackage: SwiftPackage,
         isDynamic: Bool
@@ -55,7 +59,7 @@ final class SizeMeasurer {
 private extension SizeMeasurer {
     func measureEmptyAppSize() throws -> SizeOnDisk {
         if verbose == false { showOrUpdateLoading(withText: "Cleaning up empty app directory...") }
-        try appManager.cleanupEmptyAppDirectory()
+        try appManager.cleanUp()
 
         if verbose {
             console.lineBreakAndWrite("Cloning empty app")

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -53,7 +53,8 @@ struct AllArguments: ParsableArguments {
             .customLong("local-path"),
         ],
         help: """
-        Either a valid git repository URL or a local directory path that contains a `Package.swift`
+        Either a valid git repository URL or a relative local directory path that contains a `Package.swift`
+        - Note: For local packages full paths are discouraged and unsupported.
         """
     )
     var url: URL
@@ -93,13 +94,22 @@ extension ParsableCommand {
         let isValidRemoteURL = arguments.url.isValidRemote
         let isValidLocalDirectory = try? arguments.url.isLocalDirectoryContainingPackageDotSwift()
 
+        guard arguments.url.absoluteString.first != "/" else {
+            throw CleanExit.message(
+                """
+                Error: Invalid argument '--url <url>'
+                Usage: Absolute paths aren't supported! Please pass a relative path to your local package.
+                """
+            )
+        }
+
         guard isValidRemoteURL || isValidLocalDirectory == true else {
             throw CleanExit.message(
                 """
                 Error: Invalid argument '--url <url>'
                 Usage: The URL must be either:
                 - A valid git repository URL that contains a `Package.swift`, e.g `https://github.com/Alamofire/Alamofire`; or
-                - A local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
+                - A relative local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
                 """
             )
         }

--- a/Tests/AppTests/Providers/BinarySizeProviders/BinarySizeProviderErrorTests.swift
+++ b/Tests/AppTests/Providers/BinarySizeProviders/BinarySizeProviderErrorTests.swift
@@ -57,14 +57,34 @@ final class BinarySizeProviderTests: XCTestCase {
         )
     }
 
-    func testUnexpectedErrorLocalizedMessage() {
-        let error = BinarySizeProviderError.unexpectedError
+    func testUnexpectedErrorLocalizedMessageWhenVerboseTrue() {
+        let error = BinarySizeProviderError.unexpectedError(
+            underlyingError: URLError(.badURL) as NSError,
+            isVerbose: true
+        )
         XCTAssertEqual(
             error.localizedDescription,
             """
             Failed to measure binary size
             Step: Undefined
-            Error: Unexpected failure. Please run with --verbose enabled for more details.
+            Error: Unexpected failure. Error Domain=NSURLErrorDomain Code=-1000 "(null)".
+
+            """
+        )
+    }
+
+    func testUnexpectedErrorLocalizedMessageWhenVerboseFalse() {
+        let error = BinarySizeProviderError.unexpectedError(
+            underlyingError: URLError(.badURL) as NSError,
+            isVerbose: false
+        )
+        XCTAssertEqual(
+            error.localizedDescription,
+            """
+            Failed to measure binary size
+            Step: Undefined
+            Error: Unexpected failure. Error Domain=NSURLErrorDomain Code=-1000 "(null)".
+            Please run with --verbose enabled for more details.
             """
         )
     }

--- a/Tests/RunTests/RunTests.swift
+++ b/Tests/RunTests/RunTests.swift
@@ -17,7 +17,7 @@ final class RunTests: XCTestCase {
             Error: Invalid argument '--url <url>'
             Usage: The URL must be either:
             - A valid git repository URL that contains a `Package.swift`, e.g `https://github.com/Alamofire/Alamofire`; or
-            - A local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
+            - A relative local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
 
             """,
             expectedError: ""
@@ -31,7 +31,17 @@ final class RunTests: XCTestCase {
             Error: Invalid argument '--url <url>'
             Usage: The URL must be either:
             - A valid git repository URL that contains a `Package.swift`, e.g `https://github.com/Alamofire/Alamofire`; or
-            - A local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
+            - A relative local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
+
+            """,
+            expectedError: ""
+        )
+
+        try runToolProcessAndAssert(
+            command: "--url /full/path",
+            expectedOutput: """
+            Error: Invalid argument '--url <url>'
+            Usage: Absolute paths aren't supported! Please pass a relative path to your local package.
 
             """,
             expectedError: ""


### PR DESCRIPTION
- Fix to pass correct relative path when adding a local package reference. The path must be adjusted to one level deeper in the directories structure as the `MeasurementApp` is cloned into `user-current-dir/swift-package-info`
399c9ad
- Clone measurement app using user current directory instead of a temporary one. It is needed for the relative path to work correctly, as resolving the relative path from a temporary directory doesn't work. As _side effect_ this adds the risk of leaving the user directory dirty in case the user manually cancels the tool after the empty app was already cloned beb2e1c
- Improve BinarySizeProvider.unexpectedError message 0ef906d