### PR TITLE
Support evaluating packages when running Swift 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,11 +19,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-argument-parser",
-            .upToNextMinor(from: "0.3.0")
+            .upToNextMinor(from: "1.0.2")
         ),
         .package(
             url: "https://github.com/tuist/XcodeProj.git",
-            .upToNextMinor(from: "7.18.0")
+            .upToNextMinor(from: "8.7.1")
         ),
         .package(
             url: "https://github.com/apple/swift-tools-support-core.git",
@@ -118,7 +118,8 @@ let package = Package(
             resources: [
                 .copy("Resources/package_full.json"),
                 .copy("Resources/package_with_multiple_dependencies.json"),
-                .copy("Resources/package_with_custom_target_dependency.json")
+                .copy("Resources/package_with_custom_target_dependency.json"),
+                .copy("Resources/package_full_swift_5_5.json")
             ]
         ),
         .target(

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -17,120 +17,9 @@ final class PackageContentTests: XCTestCase {
         let fixtureData = try dataFromJSON(named: "package_full", bundle: .module)
         let packageContent = try jsonDecoder.decode(PackageContent.self, from: fixtureData)
 
-        let expectedPackageContent = PackageContent(
-            name: "SomePackage",
-            platforms: [
-                .init(
-                    platformName: "ios",
-                    version: "9.0"
-                ),
-                .init(
-                    platformName: "macos",
-                    version: "10.15"
-                )
-            ],
-            products: [
-                .init(
-                    name: "Product1",
-                    targets: [
-                        "Target1",
-                        "Target2"
-                    ],
-                    kind: .library(.automatic)
-                ),
-                .init(
-                    name: "Product2",
-                    targets: [
-                        "Target1",
-                        "Target3"
-                    ],
-                    kind: .library(.static)
-                ),
-                .init(
-                    name: "Product3",
-                    targets: [
-                        "Target2"
-                    ],
-                    kind: .executable
-                ),
-                .init(
-                    name: "Product4",
-                    targets: [
-                        "Target1"
-                    ],
-                    kind: .library(.dynamic)
-                )
-            ],
-            dependencies: [
-                .init(
-                    name: "swift-argument-parser",
-                    urlString: "https://github.com/apple/swift-argument-parser",
-                    requirement: .init(
-                        range: [
-                            .init(
-                                lowerBound: "0.3.0",
-                                upperBound: "0.4.0"
-                            )
-                        ],
-                        revision: [],
-                        branch: []
-                    )
-                )
-            ],
-            targets: [
-                .init(
-                    name: "Target1",
-                    dependencies: [
-                        .product(
-                            [
-                                .name("swift-argument-parser")
-                            ]
-                        )
-                    ],
-                    kind: .regular
-                ),
-                .init(
-                    name: "Target2",
-                    dependencies: [
-                        .byName(
-                            [
-                                .name("Target1")
-                            ]
-                        )
-                    ],
-                    kind: .binary
-                ),
-                .init(
-                    name: "Target3",
-                    dependencies: [
-                        .product(
-                            [
-                                .name("ArgumentParser"),
-                                .name("swift-argument-parser")
-                            ]
-                        ),
-                        .target(
-                            [
-                                .name("Target1")
-                            ]
-                        )
-                    ],
-                    kind: .test
-                ),
-                .init(
-                    name: "Target4",
-                    dependencies: [],
-                    kind: .system
-                )
-            ],
-            swiftLanguageVersions: [
-                "5"
-            ]
-        )
-
         XCTAssertEqual(
             packageContent,
-            expectedPackageContent
+            .defaultExpectedFullPackage
         )
     }
 
@@ -321,4 +210,134 @@ final class PackageContentTests: XCTestCase {
             expectedPackageContent
         )
     }
+
+    func testWhenPackageContentIsGeneratedFromSwift5Dot5Toolchain() throws {
+        let fixtureData = try dataFromJSON(
+            named: "package_full_swift_5_5",
+            bundle: .module
+        )
+        let packageContent = try jsonDecoder.decode(PackageContent.self, from: fixtureData)
+
+        XCTAssertEqual(
+            packageContent,
+            .defaultExpectedFullPackage
+        )
+    }
+}
+
+// MARK: - Fixtures
+
+private extension PackageContent {
+    static let defaultExpectedFullPackage: Self = {
+        .init(
+            name: "SomePackage",
+            platforms: [
+                .init(
+                    platformName: "ios",
+                    version: "9.0"
+                ),
+                .init(
+                    platformName: "macos",
+                    version: "10.15"
+                )
+            ],
+            products: [
+                .init(
+                    name: "Product1",
+                    targets: [
+                        "Target1",
+                        "Target2"
+                    ],
+                    kind: .library(.automatic)
+                ),
+                .init(
+                    name: "Product2",
+                    targets: [
+                        "Target1",
+                        "Target3"
+                    ],
+                    kind: .library(.static)
+                ),
+                .init(
+                    name: "Product3",
+                    targets: [
+                        "Target2"
+                    ],
+                    kind: .executable
+                ),
+                .init(
+                    name: "Product4",
+                    targets: [
+                        "Target1"
+                    ],
+                    kind: .library(.dynamic)
+                )
+            ],
+            dependencies: [
+                .init(
+                    name: "swift-argument-parser",
+                    urlString: "https://github.com/apple/swift-argument-parser",
+                    requirement: .init(
+                        range: [
+                            .init(
+                                lowerBound: "0.3.0",
+                                upperBound: "0.4.0"
+                            )
+                        ],
+                        revision: [],
+                        branch: []
+                    )
+                )
+            ],
+            targets: [
+                .init(
+                    name: "Target1",
+                    dependencies: [
+                        .product(
+                            [
+                                .name("swift-argument-parser")
+                            ]
+                        )
+                    ],
+                    kind: .regular
+                ),
+                .init(
+                    name: "Target2",
+                    dependencies: [
+                        .byName(
+                            [
+                                .name("Target1")
+                            ]
+                        )
+                    ],
+                    kind: .binary
+                ),
+                .init(
+                    name: "Target3",
+                    dependencies: [
+                        .product(
+                            [
+                                .name("ArgumentParser"),
+                                .name("swift-argument-parser")
+                            ]
+                        ),
+                        .target(
+                            [
+                                .name("Target1")
+                            ]
+                        )
+                    ],
+                    kind: .test
+                ),
+                .init(
+                    name: "Target4",
+                    dependencies: [],
+                    kind: .system
+                )
+            ],
+            swiftLanguageVersions: [
+                "5"
+            ]
+        )
+    }()
 }

--- a/Tests/CoreTests/Resources/package_full_swift_5_5.json
+++ b/Tests/CoreTests/Resources/package_full_swift_5_5.json
@@ -1,0 +1,187 @@
+{
+  "cLanguageStandard" : null,
+  "cxxLanguageStandard" : null,
+  "dependencies": [
+    {
+      "scm": [
+        {
+          "identity": "swift-argument-parser",
+           "location": "https://github.com/apple/swift-argument-parser",
+           "name": "swift-argument-parser",
+           "productFilter": null,
+           "requirement": {
+             "range": [
+               {
+                 "lowerBound": "0.3.0",
+                 "upperBound": "0.4.0"
+               }
+             ]
+           }
+        }
+     ]
+   }
+  ],
+  "name" : "SomePackage",
+  "pkgConfig" : null,
+  "platforms" : [
+    {
+      "options" : [
+
+      ],
+      "platformName" : "ios",
+      "version" : "9.0"
+    },
+    {
+      "options" : [
+
+      ],
+      "platformName" : "macos",
+      "version" : "10.15"
+    }
+  ],
+  "products" : [
+    {
+      "name" : "Product1",
+      "targets" : [
+        "Target1",
+        "Target2"
+      ],
+      "type" : {
+        "library" : [
+          "automatic"
+        ]
+      }
+    },
+    {
+      "name" : "Product2",
+      "targets" : [
+        "Target1",
+        "Target3"
+      ],
+      "type" : {
+        "library" : [
+          "static"
+        ]
+      }
+    },
+    {
+      "name" : "Product3",
+      "targets" : [
+        "Target2"
+      ],
+      "type" : {
+        "executable" : null
+      }
+    },
+    {
+      "name" : "Product4",
+      "targets" : [
+        "Target1"
+      ],
+      "type" : {
+        "library" : [
+          "dynamic"
+        ]
+      }
+    }
+  ],
+  "providers" : null,
+  "swiftLanguageVersions" : [
+    "5"
+  ],
+  "targets" : [
+    {
+      "dependencies" : [
+        {
+          "product" : [
+            "swift-argument-parser",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Target1",
+      "path" : "Path1",
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "Target1",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Target2",
+      "path" : "Sources/2",
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "binary"
+    },
+    {
+      "dependencies" : [
+        {
+          "product" : [
+            "ArgumentParser",
+            "swift-argument-parser",
+            null
+          ]
+        },
+        {
+          "target" : [
+            "Target1",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Target3",
+      "path" : "Tests",
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "test"
+    },
+    {
+      "dependencies" : [
+
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Target4",
+      "path" : "Path",
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "system"
+    }
+  ],
+  "toolsVersion" : {
+    "_version" : "5.0.0"
+  }
+}


### PR DESCRIPTION
This fix the tool to correctly analyze packages when being run from the Swift 5.5 toolchain.

On Swift 5.5 the command `swift package-dump \(someLocalPackage)` generates a dump that is slightly different from what Swift Package Info currently supports.

This PR fixes that by adapting the `Decodable` `PackageContent` to smartly map dependencies on the different generated formats, like below: 
 
#### Swift 5.3
```json
"dependencies" : [
    {
      "explicitName" : "SnapshotTesting",
      "name" : "SnapshotTesting",
      "requirement" : {
        "range" : [
          {
            "lowerBound" : "1.8.2",
            "upperBound" : "1.9.0"
          }
        ]
      },
      "url" : "https:\/\/github.com\/pointfreeco\/swift-snapshot-testing"
    }
  ]
```

#### Swift 5.5
```json
"dependencies" : [
    {
      "scm" : [
        {
          "identity" : "swift-snapshot-testing",
          "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
          "name" : "SnapshotTesting",
          "productFilter" : null,
          "requirement" : {
            "range" : [
              {
                "lowerBound" : "1.8.2",
                "upperBound" : "1.9.0"
              }
            ]
          }
        }
      ]
    }
  ]
```

Tests were made with Swift 5.4 and all seems good.
On releases of future Swift versions, such as 5.6 and the awaited 6.0, another checks should be made to ensure the tool still works as expected.

This should fix #29. 