### PR TITLE
Fix decoding Package dump

### DIFF
--- a/MeasurementApp/ContentView.swift
+++ b/MeasurementApp/ContentView.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ContentView.swift
-//  MeasurementApp
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 27.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import SwiftUI
 

--- a/MeasurementApp/MeasurementApp.swift
+++ b/MeasurementApp/MeasurementApp.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  MeasurementApp.swift
-//  MeasurementApp
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 27.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import SwiftUI
 

--- a/Package.swift
+++ b/Package.swift
@@ -116,10 +116,7 @@ let package = Package(
                 .target(name: "CoreTestSupport")
             ],
             resources: [
-                .copy("Resources/package_full.json"),
-                .copy("Resources/package_with_multiple_dependencies.json"),
-                .copy("Resources/package_with_custom_target_dependency.json"),
-                .copy("Resources/package_full_swift_5_5.json")
+                .process("Resources")
             ]
         ),
         .target(

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  AppManager.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 29.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 import Core

--- a/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
+++ b/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  BinarySizeProvider.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 02.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 import Foundation

--- a/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
+++ b/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Measure.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 29.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 import Core

--- a/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
+++ b/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
@@ -135,7 +135,7 @@ struct DependenciesInformation: Equatable, CustomConsoleMessagesConvertible {
                         hasLineBreakAfter: false
                     ),
                     .init(
-                        text: " v. \(dependency.requirement.range.first?.lowerBound ?? "")",
+                        text: " v. \(dependency.requirement?.range.first?.lowerBound ?? "")",
                         hasLineBreakAfter: false
                     )
                 ]
@@ -171,9 +171,9 @@ extension DependenciesInformation.Dependency {
     init(from dependency: PackageContent.Dependency) {
         self.init(
             name: dependency.name,
-            version: dependency.requirement.range.first?.lowerBound.description,
-            branch: dependency.requirement.branch.first,
-            revision: dependency.requirement.revision.first
+            version: dependency.requirement?.range.first?.lowerBound.description,
+            branch: dependency.requirement?.branch.first,
+            revision: dependency.requirement?.revision.first
         )
     }
 }

--- a/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
+++ b/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  DependenciesProvider.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 24.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 import Foundation

--- a/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
+++ b/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  PlatformsProvider.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 24.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 

--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  SwiftPackageService.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 09.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 import Combine

--- a/Sources/App/Services/SwiftPackageService/TagsResponse.swift
+++ b/Sources/App/Services/SwiftPackageService/TagsResponse.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  TagsResponse.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 10.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 struct TagsResponse: Equatable {
     struct Tag: Decodable, Equatable {

--- a/Sources/Core/Console.swift
+++ b/Sources/Core/Console.swift
@@ -20,7 +20,7 @@ public enum ConsoleColor {
     case cyan
     case white
     case black
-    case grey
+    case gray
 }
 
 private extension ConsoleColor {
@@ -29,7 +29,7 @@ private extension ConsoleColor {
             case .black: return .black
             case .cyan: return .cyan
             case .green: return .green
-            case .grey: return .grey
+            case .gray: return .gray
             case .noColor: return .noColor
             case .red: return .red
             case .white: return .white

--- a/Sources/Core/Extensions/Array+Core.swift
+++ b/Sources/Core/Extensions/Array+Core.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Array+Core.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 10.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 

--- a/Sources/Core/Extensions/ExpressibleByArgument+Core.swift
+++ b/Sources/Core/Extensions/ExpressibleByArgument+Core.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ExpressibleByArgument+Core.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 21.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 import Foundation

--- a/Sources/Core/Extensions/JSONEncoder+Core.swift
+++ b/Sources/Core/Extensions/JSONEncoder+Core.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  JSONEncoder+Core.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 20.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 

--- a/Sources/Core/Extensions/KeyPath+Core.swift
+++ b/Sources/Core/Extensions/KeyPath+Core.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  KeyPath+Core.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 10.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 public func ==<T, V: Equatable>(lhs: KeyPath<T, V>, rhs: V) -> (T) -> Bool {
     return { $0[keyPath: lhs] == rhs }

--- a/Sources/Core/Extensions/Result+Core.swift
+++ b/Sources/Core/Extensions/Result+Core.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Result+Core.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 02.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 public extension Result {
     var value: Success? {

--- a/Sources/Core/InfoProvider.swift
+++ b/Sources/Core/InfoProvider.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  InfoProvider.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 02.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  PackageContent.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 23.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 import struct TSCUtility.Version

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -219,6 +219,7 @@ extension PackageContent.Dependency.Requirement: Decodable {
 extension PackageContent.Dependency: Decodable {
     private enum CodingKeys: String, CodingKey {
         case name
+        case identity
         case urlString = "url"
         case location
         case requirement
@@ -240,9 +241,12 @@ extension PackageContent.Dependency: Decodable {
 
             self = firstSCMInnerDependency
         } else {
-            self.name = try container.decode(String.self, forKey: .name)
+            self.name = try container.decodeIfPresent(String.self, forKey: .name)
+            ?? container.decode(String.self, forKey: .identity)
+
             self.urlString = try container.decodeIfPresent(String.self, forKey: .urlString)
-                ?? container.decode(String.self, forKey: .location)
+            ?? container.decode(String.self, forKey: .location)
+
             self.requirement = try container.decode(Requirement.self, forKey: .requirement)
         }
     }

--- a/Sources/Core/Models/SizeOnDisk.swift
+++ b/Sources/Core/Models/SizeOnDisk.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  SizeOnDisk.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 29.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 

--- a/Sources/Core/Models/SwiftPackage.swift
+++ b/Sources/Core/Models/SwiftPackage.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  SwiftPackage.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 30.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import struct Foundation.URL
 

--- a/Sources/Core/Shell.swift
+++ b/Sources/Core/Shell.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Shell.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 27.12.20.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 

--- a/Sources/CoreTestSupport/Doubles/Fixtures/Fixture+ProvidedInfo.swift
+++ b/Sources/CoreTestSupport/Doubles/Fixtures/Fixture+ProvidedInfo.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Fixture+ProvidedInfo.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 20.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 

--- a/Sources/CoreTestSupport/Doubles/Fixtures/Fixture+SwiftPackage.swift
+++ b/Sources/CoreTestSupport/Doubles/Fixtures/Fixture+SwiftPackage.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Fixture+SwiftPackage.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 07.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 

--- a/Sources/CoreTestSupport/Doubles/Fixtures/Fixture.swift
+++ b/Sources/CoreTestSupport/Doubles/Fixtures/Fixture.swift
@@ -1,8 +1,21 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Fixture.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 07.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 public enum Fixture {}

--- a/Sources/CoreTestSupport/Doubles/Mocks/ProgressAnimationMock.swift
+++ b/Sources/CoreTestSupport/Doubles/Mocks/ProgressAnimationMock.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ProgressAnimationMock.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 20.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import TSCUtility
 

--- a/Sources/CoreTestSupport/Doubles/Mocks/TerminalControllerMock.swift
+++ b/Sources/CoreTestSupport/Doubles/Mocks/TerminalControllerMock.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  TerminalControllerMock.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 20.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 

--- a/Sources/CoreTestSupport/Extensions/XCTest+TestSupport.swift
+++ b/Sources/CoreTestSupport/Extensions/XCTest+TestSupport.swift
@@ -8,9 +8,18 @@
 import XCTest
 
 public extension XCTestCase {
-    func dataFromJSON(named name: String, bundle: Bundle) throws -> Data {
+    func dataFromJSON(
+        named name: String,
+        bundle: Bundle,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> Data {
         let jsonData = try bundle.url(forResource: name, withExtension: "json")
             .flatMap { try Data(contentsOf: $0) }
-        return try XCTUnwrap(jsonData)
+        return try XCTUnwrap(
+            jsonData,
+            file: file,
+            line: line
+        )
     }
 }

--- a/Sources/CoreTestSupport/Extensions/XCTest+TestSupport.swift
+++ b/Sources/CoreTestSupport/Extensions/XCTest+TestSupport.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  XCTest+TestSupport.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 23.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 

--- a/Sources/Reports/ExpressibleByArgument+Reports.swift
+++ b/Sources/Reports/ExpressibleByArgument+Reports.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ExpressibleByArgument+Reports.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 21.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 

--- a/Sources/Reports/Generators/JSONDumpReportGenerator.swift
+++ b/Sources/Reports/Generators/JSONDumpReportGenerator.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  JSONDumpReportGenerator.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 20.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 import Foundation

--- a/Sources/Reports/Generators/ReportGenerating.swift
+++ b/Sources/Reports/Generators/ReportGenerating.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ReportGenerating.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 20.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 

--- a/Sources/Reports/Report.swift
+++ b/Sources/Reports/Report.swift
@@ -1,3 +1,23 @@
+//  Copyright (c) 2022 Felipe Marino
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
 import TSCBasic
 import Core
 

--- a/Sources/Reports/ReportCell.swift
+++ b/Sources/Reports/ReportCell.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ReportCell.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 02.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 

--- a/Sources/Reports/ReportFormat.swift
+++ b/Sources/Reports/ReportFormat.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ReportFormat.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 20.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 

--- a/Sources/Reports/Reporting.swift
+++ b/Sources/Reports/Reporting.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Reporting.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 02.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Core
 

--- a/Sources/Run/Subcommands/BinarySize.swift
+++ b/Sources/Run/Subcommands/BinarySize.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  BinarySize.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 03.01.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 import Core

--- a/Sources/Run/Subcommands/Dependencies.swift
+++ b/Sources/Run/Subcommands/Dependencies.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Dependencies.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 03.01.21.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 import Core

--- a/Sources/Run/Subcommands/FullAnalyzes.swift
+++ b/Sources/Run/Subcommands/FullAnalyzes.swift
@@ -1,12 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  FullAnalyzes.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  SwiftPackageInfo.swift
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//
-//  Created by Marino Felipe on 03.01.21.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 import App

--- a/Sources/Run/Subcommands/Platforms.swift
+++ b/Sources/Run/Subcommands/Platforms.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Platforms.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 03.01.21.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 import Core

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  SwiftPackageInfo.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 29.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 import struct Foundation.URL

--- a/Sources/Run/TSCUtility+Run.swift
+++ b/Sources/Run/TSCUtility+Run.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  TSCUtility+Run.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 31.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import ArgumentParser
 import TSCUtility

--- a/Sources/Run/TSCUtility+Run.swift
+++ b/Sources/Run/TSCUtility+Run.swift
@@ -23,7 +23,7 @@ import TSCUtility
 
 extension TSCUtility.Version: ExpressibleByArgument {
     public init?(argument: String) {
-        self.init(string: argument)
+        self.init(argument)
     }
 
     public var defaultValueDescription: String { "1.2.12" }

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -1,1 +1,21 @@
+//  Copyright (c) 2022 Felipe Marino
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
 SwiftPackageInfo.main()

--- a/Tests/AppTests/Fixtures/Fixture+PackageContent.swift
+++ b/Tests/AppTests/Fixtures/Fixture+PackageContent.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  Fixture+PackageContent.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 07.03.21.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 import CoreTestSupport

--- a/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderErrorTests.swift
+++ b/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderErrorTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  BinarySizeProviderErrorTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 31.01.20.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 @testable import App

--- a/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderTests.swift
+++ b/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  BinarySizeProviderTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 14.03.21.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import CoreTestSupport

--- a/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
+++ b/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  BinarySizeProviderErrorTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 31.01.20.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import CoreTestSupport

--- a/Tests/AppTests/Providers/PlatformsProvider/PlatformsProviderTests.swift
+++ b/Tests/AppTests/Providers/PlatformsProvider/PlatformsProviderTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  PlatformsProviderTests.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 14.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import CoreTestSupport

--- a/Tests/AppTests/Services/SwiftPackageService/TagsResponseTests.swift
+++ b/Tests/AppTests/Services/SwiftPackageService/TagsResponseTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  TagsResponseTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 29.12.20.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 @testable import App

--- a/Tests/CoreTests/Helpers/FileManager+CoreTests.swift
+++ b/Tests/CoreTests/Helpers/FileManager+CoreTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  FileManager+CoreTests.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 29.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import Foundation
 

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  PackageContentTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 29.12.20.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import CoreTestSupport

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -32,7 +32,7 @@ final class PackageContentTests: XCTestCase {
 
         XCTAssertEqual(
             packageContent,
-            .defaultExpectedFullPackage
+            .defaultExpectedFullPackage()
         )
     }
 
@@ -233,7 +233,42 @@ final class PackageContentTests: XCTestCase {
 
         XCTAssertEqual(
             packageContent,
-            .defaultExpectedFullPackage
+            .defaultExpectedFullPackage()
+        )
+    }
+
+    func testWhenPackageContentIsGeneratedFromSwift5Dot6Toolchain() throws {
+        let fixtureData = try dataFromJSON(
+            named: "package_full_swift_5_6",
+            bundle: .module
+        )
+        let packageContent = try jsonDecoder.decode(PackageContent.self, from: fixtureData)
+
+        XCTAssertEqual(
+            packageContent,
+            .defaultExpectedFullPackage(
+                dependencies: [
+                    .init(
+                        name: "swift-argument-parser",
+                        urlString: "https://github.com/apple/swift-argument-parser",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "0.3.0",
+                                    upperBound: "0.4.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    ),
+                    .init(
+                        name: "packages",
+                        urlString: "path/Packages",
+                        requirement: nil
+                    )
+                ]
+            )
         )
     }
 
@@ -246,7 +281,7 @@ final class PackageContentTests: XCTestCase {
 
         XCTAssertEqual(
             packageContent,
-            .defaultExpectedFullPackage,
+            .defaultExpectedFullPackage(),
             "Package should be decoded correctly when dependency has identity over name"
         )
     }
@@ -255,7 +290,24 @@ final class PackageContentTests: XCTestCase {
 // MARK: - Fixtures
 
 private extension PackageContent {
-    static let defaultExpectedFullPackage: Self = {
+    static func defaultExpectedFullPackage(
+        dependencies: [PackageContent.Dependency] = [
+            .init(
+                name: "swift-argument-parser",
+                urlString: "https://github.com/apple/swift-argument-parser",
+                requirement: .init(
+                    range: [
+                        .init(
+                            lowerBound: "0.3.0",
+                            upperBound: "0.4.0"
+                        )
+                    ],
+                    revision: [],
+                    branch: []
+                )
+            )
+        ]
+    ) -> Self {
         .init(
             name: "SomePackage",
             platforms: [
@@ -300,22 +352,7 @@ private extension PackageContent {
                     kind: .library(.dynamic)
                 )
             ],
-            dependencies: [
-                .init(
-                    name: "swift-argument-parser",
-                    urlString: "https://github.com/apple/swift-argument-parser",
-                    requirement: .init(
-                        range: [
-                            .init(
-                                lowerBound: "0.3.0",
-                                upperBound: "0.4.0"
-                            )
-                        ],
-                        revision: [],
-                        branch: []
-                    )
-                )
-            ],
+            dependencies: dependencies,
             targets: [
                 .init(
                     name: "Target1",
@@ -366,5 +403,5 @@ private extension PackageContent {
                 "5"
             ]
         )
-    }()
+    }
 }

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -223,6 +223,20 @@ final class PackageContentTests: XCTestCase {
             .defaultExpectedFullPackage
         )
     }
+
+    func testWhenPackageDependencyHasIdentityOnly() throws {
+        let fixtureData = try dataFromJSON(
+            named: "package_identity_dependency",
+            bundle: .module
+        )
+        let packageContent = try jsonDecoder.decode(PackageContent.self, from: fixtureData)
+
+        XCTAssertEqual(
+            packageContent,
+            .defaultExpectedFullPackage,
+            "Package should be decoded correctly when dependency has identity over name"
+        )
+    }
 }
 
 // MARK: - Fixtures

--- a/Tests/CoreTests/Models/SizeOnDiskTests.swift
+++ b/Tests/CoreTests/Models/SizeOnDiskTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  SizeOnDiskTests.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 29.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 @testable import Core

--- a/Tests/CoreTests/Models/SwiftPackageTests.swift
+++ b/Tests/CoreTests/Models/SwiftPackageTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  SwiftPackageTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 29.12.20.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import CoreTestSupport

--- a/Tests/CoreTests/ProvidedInfoTests.swift
+++ b/Tests/CoreTests/ProvidedInfoTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ProvidedInfoTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 14.03.21.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 @testable import Core

--- a/Tests/CoreTests/Resources/package_full_swift_5_6.json
+++ b/Tests/CoreTests/Resources/package_full_swift_5_6.json
@@ -1,27 +1,44 @@
 {
     "cLanguageStandard" : null,
     "cxxLanguageStandard" : null,
-    "dependencies": [
+    "dependencies" : [
         {
-            "scm": [
+            "sourceControl" : [
                 {
                     "identity": "swift-argument-parser",
-                    "location": "https://github.com/apple/swift-argument-parser",
-                    "name": "swift-argument-parser",
-                    "productFilter": null,
-                    "requirement": {
-                        "range": [
+                    "location" : {
+                        "remote" : [
+                            "https://github.com/apple/swift-argument-parser"
+                        ]
+                    },
+                    "productFilter" : null,
+                    "requirement" : {
+                        "range" : [
                             {
-                                "lowerBound": "0.3.0",
-                                "upperBound": "0.4.0"
+                                "lowerBound" : "0.3.0",
+                                "upperBound" : "0.4.0"
                             }
                         ]
                     }
+                }
+            ],
+        },
+        {
+            "fileSystem" : [
+                {
+                    "identity" : "packages",
+                    "path" : "path/Packages",
+                    "productFilter" : null
                 }
             ]
         }
     ],
     "name" : "SomePackage",
+    "packageKind" : {
+        "root" : [
+            "path/swift-argument-parser"
+        ]
+    },
     "pkgConfig" : null,
     "platforms" : [
         {
@@ -182,6 +199,6 @@
         }
     ],
     "toolsVersion" : {
-        "_version" : "5.0.0"
+        "_version" : "5.3.0"
     }
 }

--- a/Tests/CoreTests/Resources/package_identity_dependency.json
+++ b/Tests/CoreTests/Resources/package_identity_dependency.json
@@ -1,0 +1,186 @@
+{
+    "cLanguageStandard" : null,
+    "cxxLanguageStandard" : null,
+    "dependencies": [
+        {
+            "scm": [
+                {
+                    "identity": "swift-argument-parser",
+                    "location": "https://github.com/apple/swift-argument-parser",
+                    "productFilter": null,
+                    "requirement": {
+                        "range": [
+                            {
+                                "lowerBound": "0.3.0",
+                                "upperBound": "0.4.0"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "name" : "SomePackage",
+    "pkgConfig" : null,
+    "platforms" : [
+        {
+            "options" : [
+
+            ],
+            "platformName" : "ios",
+            "version" : "9.0"
+        },
+        {
+            "options" : [
+
+            ],
+            "platformName" : "macos",
+            "version" : "10.15"
+        }
+    ],
+    "products" : [
+        {
+            "name" : "Product1",
+            "targets" : [
+                "Target1",
+                "Target2"
+            ],
+            "type" : {
+                "library" : [
+                    "automatic"
+                ]
+            }
+        },
+        {
+            "name" : "Product2",
+            "targets" : [
+                "Target1",
+                "Target3"
+            ],
+            "type" : {
+                "library" : [
+                    "static"
+                ]
+            }
+        },
+        {
+            "name" : "Product3",
+            "targets" : [
+                "Target2"
+            ],
+            "type" : {
+                "executable" : null
+            }
+        },
+        {
+            "name" : "Product4",
+            "targets" : [
+                "Target1"
+            ],
+            "type" : {
+                "library" : [
+                    "dynamic"
+                ]
+            }
+        }
+    ],
+    "providers" : null,
+    "swiftLanguageVersions" : [
+        "5"
+    ],
+    "targets" : [
+        {
+            "dependencies" : [
+                {
+                    "product" : [
+                        "swift-argument-parser",
+                        null
+                    ]
+                }
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target1",
+            "path" : "Path1",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "regular"
+        },
+        {
+            "dependencies" : [
+                {
+                    "byName" : [
+                        "Target1",
+                        null
+                    ]
+                }
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target2",
+            "path" : "Sources/2",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "binary"
+        },
+        {
+            "dependencies" : [
+                {
+                    "product" : [
+                        "ArgumentParser",
+                        "swift-argument-parser",
+                        null
+                    ]
+                },
+                {
+                    "target" : [
+                        "Target1",
+                        null
+                    ]
+                }
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target3",
+            "path" : "Tests",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "test"
+        },
+        {
+            "dependencies" : [
+
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target4",
+            "path" : "Path",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "system"
+        }
+    ],
+    "toolsVersion" : {
+        "_version" : "5.0.0"
+    }
+}

--- a/Tests/CoreTests/URLExtensionTests.swift
+++ b/Tests/CoreTests/URLExtensionTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  URLExtensionTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 29.12.20.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 @testable import Core

--- a/Tests/ReportsTests/Generators/ConsoleReportGeneratorTests.swift
+++ b/Tests/ReportsTests/Generators/ConsoleReportGeneratorTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  ConsoleReportGeneratorTests.swift
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
-//  Created by Marino Felipe on 14.03.21.
-//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import CoreTestSupport

--- a/Tests/ReportsTests/Generators/JSONDumpReportGeneratorTests.swift
+++ b/Tests/ReportsTests/Generators/JSONDumpReportGeneratorTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  JSONDumpReportGeneratorTests.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 21.03.21.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import CoreTestSupport

--- a/Tests/RunTests/RunTests.swift
+++ b/Tests/RunTests/RunTests.swift
@@ -1,9 +1,22 @@
+//  Copyright (c) 2022 Felipe Marino
 //
-//  RunTests.swift
-//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
-//  Created by Marino Felipe on 28.12.20.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 import XCTest
 import Foundation


### PR DESCRIPTION
- Mainly fixes decoding the json dump of Package.swift when generated using swift's 5.6 toolchain
- Improve performance of Shell commands (to be revisited alongside timeout that was disabled since was broken)
- Fix warnings
- Update file headers