### PR TITLE
Fix decoding Swift 5.9 package content

### DIFF
--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -73,9 +73,20 @@ public struct PackageContent: Decodable, Equatable {
             public let revision: [String]
             public let branch: [String]
         }
+
+      #if compiler(<5.9)
         public struct Location: Decodable, Equatable, Hashable {
             public let remote: [String]
         }
+      #else
+        public struct Location: Decodable, Hashable {
+          public struct RemoteURL: Decodable, Hashable {
+            let urlString: String
+          }
+
+          public let remote: [RemoteURL]
+        }
+      #endif
 
         public let name: String
         public let urlString: String
@@ -291,7 +302,11 @@ extension PackageContent.Dependency: Decodable {
                 let location = try? container.decode(Location.self, forKey: .location),
                 let remote = location.remote.first
             {
+              #if compiler(<5.9)
                 self.urlString = remote
+              #else
+                self.urlString = remote.urlString
+              #endif
             } else {
                 self.urlString = try container.decodeIfPresent(String.self, forKey: .urlString)
                 ?? container.decodeIfPresent(String.self, forKey: .path)

--- a/Sources/Core/Models/PackageContent.swift
+++ b/Sources/Core/Models/PackageContent.swift
@@ -74,19 +74,19 @@ public struct PackageContent: Decodable, Equatable {
             public let branch: [String]
         }
 
-      #if compiler(<5.9)
+        #if compiler(<5.9)
         public struct Location: Decodable, Equatable, Hashable {
             public let remote: [String]
         }
-      #else
+        #else
         public struct Location: Decodable, Hashable {
-          public struct RemoteURL: Decodable, Hashable {
-            let urlString: String
-          }
+            public struct RemoteURL: Decodable, Hashable {
+                let urlString: String
+            }
 
-          public let remote: [RemoteURL]
+            public let remote: [RemoteURL]
         }
-      #endif
+        #endif
 
         public let name: String
         public let urlString: String
@@ -302,11 +302,11 @@ extension PackageContent.Dependency: Decodable {
                 let location = try? container.decode(Location.self, forKey: .location),
                 let remote = location.remote.first
             {
-              #if compiler(<5.9)
+                #if compiler(<5.9)
                 self.urlString = remote
-              #else
+                #else
                 self.urlString = remote.urlString
-              #endif
+                #endif
             } else {
                 self.urlString = try container.decodeIfPresent(String.self, forKey: .urlString)
                 ?? container.decodeIfPresent(String.self, forKey: .path)

--- a/Tests/CoreTests/Models/PackageContentTests.swift
+++ b/Tests/CoreTests/Models/PackageContentTests.swift
@@ -224,6 +224,7 @@ final class PackageContentTests: XCTestCase {
         )
     }
 
+    #if compiler(>=5.5)
     func testWhenPackageContentIsGeneratedFromSwift5Dot5Toolchain() throws {
         let fixtureData = try dataFromJSON(
             named: "package_full_swift_5_5",
@@ -236,7 +237,10 @@ final class PackageContentTests: XCTestCase {
             .defaultExpectedFullPackage()
         )
     }
+    #endif
 
+  
+    #if compiler(<5.7)
     func testWhenPackageContentIsGeneratedFromSwift5Dot6Toolchain() throws {
         let fixtureData = try dataFromJSON(
             named: "package_full_swift_5_6",
@@ -271,6 +275,44 @@ final class PackageContentTests: XCTestCase {
             )
         )
     }
+    #endif
+
+    #if compiler(>=5.9)
+    func testWhenPackageContentIsGeneratedFromSwift5Dot9Toolchain() throws {
+        let fixtureData = try dataFromJSON(
+            named: "package_full_swift_5_9",
+            bundle: .module
+        )
+        let packageContent = try jsonDecoder.decode(PackageContent.self, from: fixtureData)
+
+        XCTAssertEqual(
+            packageContent,
+            .defaultExpectedFullPackage(
+                dependencies: [
+                    .init(
+                        name: "swift-argument-parser",
+                        urlString: "https://github.com/apple/swift-argument-parser",
+                        requirement: .init(
+                            range: [
+                                .init(
+                                    lowerBound: "0.3.0",
+                                    upperBound: "0.4.0"
+                                )
+                            ],
+                            revision: [],
+                            branch: []
+                        )
+                    ),
+                    .init(
+                        name: "packages",
+                        urlString: "path/Packages",
+                        requirement: nil
+                    )
+                ]
+            )
+        )
+    }
+    #endif
 
     func testWhenPackageDependencyHasIdentityOnly() throws {
         let fixtureData = try dataFromJSON(

--- a/Tests/CoreTests/Resources/package_full_swift_5_9.json
+++ b/Tests/CoreTests/Resources/package_full_swift_5_9.json
@@ -1,0 +1,206 @@
+{
+    "cLanguageStandard" : null,
+    "cxxLanguageStandard" : null,
+    "dependencies" : [
+        {
+            "sourceControl" : [
+                {
+                    "identity": "swift-argument-parser",
+                    "location" : {
+                        "remote" : [
+                            {
+                                "urlString": "https://github.com/apple/swift-argument-parser"
+                            }
+                        ]
+                    },
+                    "productFilter" : null,
+                    "requirement" : {
+                        "range" : [
+                            {
+                                "lowerBound" : "0.3.0",
+                                "upperBound" : "0.4.0"
+                            }
+                        ]
+                    }
+                }
+            ],
+        },
+        {
+            "fileSystem" : [
+                {
+                    "identity" : "packages",
+                    "path" : "path/Packages",
+                    "productFilter" : null
+                }
+            ]
+        }
+    ],
+    "name" : "SomePackage",
+    "packageKind" : {
+        "root" : [
+            "path/swift-argument-parser"
+        ]
+    },
+    "pkgConfig" : null,
+    "platforms" : [
+        {
+            "options" : [
+
+            ],
+            "platformName" : "ios",
+            "version" : "9.0"
+        },
+        {
+            "options" : [
+
+            ],
+            "platformName" : "macos",
+            "version" : "10.15"
+        }
+    ],
+    "products" : [
+        {
+            "name" : "Product1",
+            "targets" : [
+                "Target1",
+                "Target2"
+            ],
+            "type" : {
+                "library" : [
+                    "automatic"
+                ]
+            }
+        },
+        {
+            "name" : "Product2",
+            "targets" : [
+                "Target1",
+                "Target3"
+            ],
+            "type" : {
+                "library" : [
+                    "static"
+                ]
+            }
+        },
+        {
+            "name" : "Product3",
+            "targets" : [
+                "Target2"
+            ],
+            "type" : {
+                "executable" : null
+            }
+        },
+        {
+            "name" : "Product4",
+            "targets" : [
+                "Target1"
+            ],
+            "type" : {
+                "library" : [
+                    "dynamic"
+                ]
+            }
+        }
+    ],
+    "providers" : null,
+    "swiftLanguageVersions" : [
+        "5"
+    ],
+    "targets" : [
+        {
+            "dependencies" : [
+                {
+                    "product" : [
+                        "swift-argument-parser",
+                        null
+                    ]
+                }
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target1",
+            "path" : "Path1",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "regular"
+        },
+        {
+            "dependencies" : [
+                {
+                    "byName" : [
+                        "Target1",
+                        null
+                    ]
+                }
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target2",
+            "path" : "Sources/2",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "binary"
+        },
+        {
+            "dependencies" : [
+                {
+                    "product" : [
+                        "ArgumentParser",
+                        "swift-argument-parser",
+                        null
+                    ]
+                },
+                {
+                    "target" : [
+                        "Target1",
+                        null
+                    ]
+                }
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target3",
+            "path" : "Tests",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "test"
+        },
+        {
+            "dependencies" : [
+
+            ],
+            "exclude" : [
+
+            ],
+            "name" : "Target4",
+            "path" : "Path",
+            "resources" : [
+
+            ],
+            "settings" : [
+
+            ],
+            "type" : "system"
+        }
+    ],
+    "toolsVersion" : {
+        "_version" : "5.3.0"
+    }
+}


### PR DESCRIPTION
A fix for decoding a package dump in Swift 5.9, it ensures that `dependencies` are correctly decoded

swift 5.9
```json
"dependencies" : [
    {
      "sourceControl" : [
        {
          "identity" : "swift-snapshot-testing",
          "location" : {
            "remote" : [
              {
                "urlString" : "https://github.com/pointfreeco/swift-snapshot-testing"
              }
            ]
          },
```

before
```json
"dependencies" : [
    {
      "sourceControl" : [
        {
          "identity" : "swift-snapshot-testing",
          "location" : {
            "remote" : [
                "https://github.com/pointfreeco/swift-snapshot-testing"
            ]
          },
```