### PR TITLE
Fix tag ordering

### DIFF
--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -223,6 +223,7 @@ public final class SwiftPackageService {
 
 private extension WorkingCheckout {
   /// Get repository tags ordered by semantic versioning
+  /// it attempts to normalize the tags by removing occurrences of `v`
   func getSemVerOrderedTags() throws -> [String] {
     try getTags().sorted(
       by: {

--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -160,7 +160,7 @@ public final class SwiftPackageService {
         editable: false
       )
 
-      let repositoryTags = try workingCopy.getTags()
+      let repositoryTags = try workingCopy.getSemVerOrderedTags()
 
       let resolvedTag: String
       let tagState: ResourceState
@@ -215,5 +215,33 @@ public final class SwiftPackageService {
         }
       }
     }
+  }
+}
+
+// MARK: - Helpers
+
+private extension WorkingCheckout {
+  func getSemVerOrderedTags() throws -> [String] {
+    try getTags().sorted(
+      by: {
+        let normalizedVersionA = $0.normalizedVersion
+        let normalizedVersionB = $1.normalizedVersion
+
+        if normalizedVersionB.first?.isNumber == false {
+          return false
+        }
+
+        return normalizedVersionA.compare(
+          normalizedVersionB,
+          options: .numeric
+        ) == .orderedAscending
+      }
+    )
+  }
+}
+
+private extension String {
+  var normalizedVersion: String {
+    replacingOccurrences(of: "v", with: "")
   }
 }

--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -28,6 +28,7 @@ import Basics
 import PackageModel
 import SourceControl
 import TSCBasic
+import TSCUtility
 
 public enum ResourceState: Equatable, CustomStringConvertible {
   case undefined
@@ -221,27 +222,28 @@ public final class SwiftPackageService {
 // MARK: - Helpers
 
 private extension WorkingCheckout {
+  /// Get repository tags ordered by semantic versioning
   func getSemVerOrderedTags() throws -> [String] {
     try getTags().sorted(
       by: {
-        let normalizedVersionA = $0.normalizedVersion
-        let normalizedVersionB = $1.normalizedVersion
-
-        if normalizedVersionB.first?.isNumber == false {
-          return false
+        guard
+          let versionA = Version($0.removingCharacterV),
+          let versionB = Version($1.removingCharacterV)
+        else {
+          return $0.compare(
+            $1,
+            options: .numeric
+          ) == .orderedAscending
         }
 
-        return normalizedVersionA.compare(
-          normalizedVersionB,
-          options: .numeric
-        ) == .orderedAscending
+        return versionA < versionB
       }
     )
   }
 }
 
 private extension String {
-  var normalizedVersion: String {
+  var removingCharacterV: String {
     replacingOccurrences(of: "v", with: "")
   }
 }

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -37,7 +37,7 @@ public struct SwiftPackageInfo: AsyncParsableCommand {
         that can be used in your favor when deciding whether to
         adopt or not a Swift Package as a dependency on your app.
         """,
-    version: "1.4.0",
+    version: "1.4.1",
     subcommands: [
       BinarySize.self,
       Platforms.self,
@@ -185,7 +185,7 @@ extension ParsableCommand {
         Console.default.lineBreakAndWrite("Package version was \(tagState.description)")
 
         if let latestTag {
-          Console.default.lineBreakAndWrite("Defaulting to latest found tag: \(latestTag)")
+          Console.default.lineBreakAndWrite("Defaulting to latest found semver tag: \(latestTag)")
           swiftPackage.version = latestTag
         }
       case .valid:


### PR DESCRIPTION
Order tags by semVer. This allows the latest to be closer to what users would want them to be.

The logic is quite simple, it attempts to normalize versions by removing occurrences of `v`.

All non semver versions are filtered out from the latest tag check.

This should resolve #15 