### PR TITLE
Support revision (commit, branch)

### DIFF
--- a/Sources/Core/Models/ResurceState.swift
+++ b/Sources/Core/Models/ResurceState.swift
@@ -1,0 +1,36 @@
+//  Copyright (c) 2022 Felipe Marino
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+public enum ResourceState: Equatable, CustomStringConvertible {
+  case undefined
+  case valid
+  case invalid
+
+  public var description: String {
+    switch self {
+    case .undefined:
+      return "undefined"
+    case .valid:
+      return "valid"
+    case .invalid:
+      return "invalid"
+    }
+  }
+}

--- a/Sources/Core/Models/SwiftPackage.swift
+++ b/Sources/Core/Models/SwiftPackage.swift
@@ -21,27 +21,47 @@
 import struct Foundation.URL
 
 public struct SwiftPackage: Equatable, CustomStringConvertible {
+  public enum Resolution: Equatable, CustomStringConvertible {
+    case version(String)
+    case revision(String)
+
+    public var description: String {
+      switch self {
+      case let .revision(revision):
+        return "Revision: \(revision)"
+      case let .version(tag):
+        return "Version: \(tag)"
+      }
+    }
+  }
+
   public let url: URL
   public let isLocal: Bool
-  public var version: String
+  public var resolution: Resolution
   public var product: String
 
   public init(
     url: URL,
     isLocal: Bool,
     version: String,
+    revision: String?,
     product: String
   ) {
     self.url = url
     self.isLocal = isLocal
-    self.version = version
     self.product = product
+
+    if let revision = revision, version == ResourceState.undefined.description {
+      self.resolution = .revision(revision)
+    } else {
+      self.resolution = .version(version)
+    }
   }
 
   public var description: String {
     """
     \(isLocal ? "Local path" : "Repository URL"): \(url)
-    Version: \(version)
+    \(resolution.description)
     Product: \(product)
     """
   }

--- a/Sources/CoreTestSupport/Doubles/Fixtures/Fixture+SwiftPackage.swift
+++ b/Sources/CoreTestSupport/Doubles/Fixtures/Fixture+SwiftPackage.swift
@@ -26,12 +26,15 @@ public extension Fixture {
   static func makeSwiftPackage(
     url: URL = URL(string: "https://www.apple.com")!,
     isLocal: Bool = false,
+    version: String = "1.0.0",
+    revision: String? = nil,
     product: String = "Some"
   ) -> SwiftPackage {
     .init(
       url: url,
       isLocal: isLocal,
-      version: "1.0.0",
+      version: version,
+      revision: revision,
       product: product
     )
   }

--- a/Sources/Reports/Report.swift
+++ b/Sources/Reports/Report.swift
@@ -22,48 +22,57 @@ import TSCBasic
 import Core
 
 public final class Report: Reporting {
-    let swiftPackage: SwiftPackage
-    private let console: Console
+  let swiftPackage: SwiftPackage
+  private let console: Console
 
-    public init(
-        swiftPackage: SwiftPackage,
-        console: Console = .default
-    ) {
-        self.swiftPackage = swiftPackage
-        self.console = console
-    }
+  public init(
+    swiftPackage: SwiftPackage,
+    console: Console = .default
+  ) {
+    self.swiftPackage = swiftPackage
+    self.console = console
+  }
 
-    public func generate(
-        for providedInfo: ProvidedInfo,
-        format: ReportFormat
-    ) throws {
-        try generate(
-            for: [providedInfo],
-            format: format
-        )
-    }
+  public func generate(
+    for providedInfo: ProvidedInfo,
+    format: ReportFormat
+  ) throws {
+    try generate(
+      for: [providedInfo],
+      format: format
+    )
+  }
 
-    public func generate(
-        for providedInfos: [ProvidedInfo],
-        format: ReportFormat
-    ) throws {
-        let reportGenerator = format.makeReportGenerator()
-        try reportGenerator(
-            swiftPackage,
-            providedInfos
-        )
-    }
+  public func generate(
+    for providedInfos: [ProvidedInfo],
+    format: ReportFormat
+  ) throws {
+    let reportGenerator = format.makeReportGenerator()
+    try reportGenerator(
+      swiftPackage,
+      providedInfos
+    )
+  }
 }
 
 // MARK: - SwiftPackage: CustomConsoleMessageConvertible
 
 extension SwiftPackage: CustomConsoleMessageConvertible {
-    public var message: ConsoleMessage {
-        .init(
-            text: "\(product), \(version)",
-            color: .cyan,
-            isBold: false,
-            hasLineBreakAfter: false
-        )
+  public var message: ConsoleMessage {
+    .init(
+      text: "\(product), \(versionOrRevision)",
+      color: .cyan,
+      isBold: false,
+      hasLineBreakAfter: false
+    )
+  }
+
+  private var versionOrRevision: String {
+    switch resolution {
+    case let .revision(revision):
+      return revision
+    case let .version(tag):
+      return tag
     }
+  }
 }


### PR DESCRIPTION
Adds a new option `-r` / `--revision` for analyzing a specific commit or branch 

The `version` option takes precedence over the added `revision`

Solves #36 

### Examples

- `./.build/debug/swift-package-info --for https://github.com/realm/realm-cocoa --product Realm -r master`
- `./.build/debug/swift-package-info --for https://github.com/realm/realm-cocoa --product Realm -r fe906bf`