### PR TITLE
Add support for custom xcconfig file

### DIFF
--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -59,14 +59,17 @@ final class AppManager {
     private let fileManager: FileManager
     private let console: Console
     private let verbose: Bool
+    private let xcconfig: URL?
 
     init(
         fileManager: FileManager = .default,
         console: Console = .default,
+        xcconfig: URL?,
         verbose: Bool
     ) {
         self.fileManager = fileManager
         self.console = console
+        self.xcconfig = xcconfig
         self.verbose = verbose
     }
 
@@ -90,6 +93,10 @@ final class AppManager {
     }
     
     func generateArchive() throws {
+        var cmdXCConfig: String = ""
+        if let xcconfig, let customXCConfigURL = URL(string: FileManager.default.currentDirectoryPath)?.appendingPathComponent(xcconfig.path) {
+            cmdXCConfig = "-xcconfig \(customXCConfigURL.path)"
+        }
         let command: ConsoleMessage = """
         xcodebuild \
         archive \
@@ -97,6 +104,7 @@ final class AppManager {
         -scheme \(Constants.appName) \
         -archivePath \(archivedPath) \
         -configuration Release \
+        \(cmdXCConfig) \
         -arch arm64 \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -93,8 +93,9 @@ final class AppManager {
     }
     
     func generateArchive() throws {
+        let workingDirectory = fileManager.currentDirectoryPath
         var cmdXCConfig: String = ""
-        if let xcconfig, let customXCConfigURL = URL(string: FileManager.default.currentDirectoryPath)?.appendingPathComponent(xcconfig.path) {
+        if let xcconfig, let customXCConfigURL = URL(string: workingDirectory)?.appendingPathComponent(xcconfig.path) {
             cmdXCConfig = "-xcconfig \(customXCConfigURL.path)"
         }
         let command: ConsoleMessage = """
@@ -117,7 +118,7 @@ final class AppManager {
 
         let output = try Shell.run(
             command.text,
-            workingDirectory: fileManager.currentDirectoryPath,
+            workingDirectory: workingDirectory,
             verbose: verbose,
             timeout: nil
         )

--- a/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
+++ b/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
@@ -64,9 +64,10 @@ public struct BinarySizeProvider {
     public static func fetchInformation(
         for swiftPackage: SwiftPackage,
         package: PackageWrapper,
+        xcconfig: URL?,
         verbose: Bool
     ) -> Result<ProvidedInfo, InfoProviderError> {
-        let sizeMeasurer = defaultSizeMeasurer(verbose)
+        let sizeMeasurer = defaultSizeMeasurer(xcconfig, verbose)
         var binarySize: SizeOnDisk = .zero
 
         let isProductDynamicLibrary = package.products
@@ -140,11 +141,11 @@ struct BinarySizeInformation: Equatable, Encodable, CustomConsoleMessagesConvert
 }
 
 #if DEBUG
-var defaultSizeMeasurer: (Bool) -> SizeMeasuring = { verbose in
-    SizeMeasurer(verbose: verbose).binarySize
+var defaultSizeMeasurer: (URL?, Bool) -> SizeMeasuring = { xcconfig, verbose in
+    SizeMeasurer(verbose: verbose, xcconfig: xcconfig).binarySize
 }
 #else
-let defaultSizeMeasurer: (Bool) -> SizeMeasuring = { verbose in
-    SizeMeasurer(verbose: verbose).binarySize
+let defaultSizeMeasurer: (URL?, Bool) -> SizeMeasuring = { xcconfig, verbose in
+    SizeMeasurer(verbose: verbose, xcconfig: xcconfig).binarySize
 }
 #endif

--- a/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
+++ b/Sources/App/Providers/BinarySizeProvider/SizeMeasurer.swift
@@ -31,12 +31,12 @@ final class SizeMeasurer {
     private let console: Console
     private let verbose: Bool
 
-    public convenience init(verbose: Bool) {
-        self.init(appManager: .init(verbose: verbose), verbose: verbose)
+    public convenience init(verbose: Bool, xcconfig: URL?) {
+        self.init(appManager: .init(xcconfig: xcconfig, verbose: verbose), verbose: verbose)
     }
 
     init(
-        appManager: AppManager = .init(verbose: true),
+        appManager: AppManager = .init(xcconfig: nil, verbose: true),
         console: Console = .default,
         verbose: Bool
     ) {

--- a/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
+++ b/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
@@ -36,6 +36,7 @@ public struct DependenciesProvider {
   public static func fetchInformation(
     for swiftPackage: SwiftPackage,
     package: PackageWrapper,
+    xcconfig: URL?,
     verbose: Bool
   ) -> Result<ProvidedInfo, InfoProviderError> {
     guard let product = package.products.first(where: { $0.name == swiftPackage.product }) else {

--- a/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
+++ b/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
@@ -19,11 +19,13 @@
 //  SOFTWARE.
 
 import Core
+import Foundation
 
 public struct PlatformsProvider {
   public static func fetchInformation(
     for swiftPackage: SwiftPackage,
     package: PackageWrapper,
+    xcconfig: URL?,
     verbose: Bool
   ) -> Result<ProvidedInfo, InfoProviderError> {
     .success(

--- a/Sources/Core/Extensions/URL+Core.swift
+++ b/Sources/Core/Extensions/URL+Core.swift
@@ -82,15 +82,21 @@ extension Array where Element == URL {
 
 public extension URL {
     static let isValidURLRegex = "^(https?://)?(www\\.)?([-a-z0-9]{1,63}\\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\\.[a-z]{2,6}(/[-\\w@\\+\\.~#\\?&/=%]*)?$"
-
+    
     var isValidRemote: Bool {
         NSPredicate(format:"SELF MATCHES %@", Self.isValidURLRegex)
             .evaluate(with: absoluteString)
     }
-
+    
     func isLocalDirectoryContainingPackageDotSwift(
         fileManager: FileManager = .default
     ) throws -> Bool {
         try fileManager.contentsOfDirectory(atPath: path).contains("Package.swift")
+    }
+    
+    func isLocalXCConfigFileValid(
+        fileManager: FileManager = .default
+    ) -> Bool {
+        fileManager.isReadableFile(atPath: path) && self.pathExtension == "xcconfig"
     }
 }

--- a/Sources/Core/InfoProvider.swift
+++ b/Sources/Core/InfoProvider.swift
@@ -45,6 +45,7 @@ public enum ProviderKind: String, CodingKey {
 public typealias InfoProvider = (
     _ swiftPackage: SwiftPackage,
     _ packageContent: PackageWrapper,
+    _ xcconfig: URL?,
     _ verbose: Bool
 ) -> Result<ProvidedInfo, InfoProviderError>
 

--- a/Sources/Run/Subcommands/BinarySize.swift
+++ b/Sources/Run/Subcommands/BinarySize.swift
@@ -63,7 +63,8 @@ extension SwiftPackageInfo {
 
       try BinarySizeProvider.fetchInformation(
         for: swiftPackage,
-        package: packageWrapper,
+        package: packageWrapper, 
+        xcconfig: allArguments.xcconfig,
         verbose: allArguments.verbose
       )
       .onSuccess {

--- a/Sources/Run/Subcommands/Dependencies.swift
+++ b/Sources/Run/Subcommands/Dependencies.swift
@@ -54,7 +54,8 @@ extension SwiftPackageInfo {
 
       try DependenciesProvider.fetchInformation(
         for: swiftPackage,
-        package: packageWrapper,
+        package: packageWrapper, 
+        xcconfig: allArguments.xcconfig,
         verbose: allArguments.verbose
       )
       .onSuccess {

--- a/Sources/Run/Subcommands/FullAnalyzes.swift
+++ b/Sources/Run/Subcommands/FullAnalyzes.swift
@@ -63,6 +63,7 @@ extension SwiftPackageInfo {
         subcommandProvider(
           swiftPackage,
           packageWrapper,
+          allArguments.xcconfig,
           allArguments.verbose
         )
         .onSuccess { providedInfos.append($0) }

--- a/Sources/Run/Subcommands/Platforms.swift
+++ b/Sources/Run/Subcommands/Platforms.swift
@@ -55,6 +55,7 @@ extension SwiftPackageInfo {
       try PlatformsProvider.fetchInformation(
         for: swiftPackage,
         package: packageWrapper,
+        xcconfig: allArguments.xcconfig,
         verbose: allArguments.verbose
       )
       .onSuccess {

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -140,15 +140,15 @@ extension ParsableCommand {
     let isValidLocalDirectory = try? arguments.url.isLocalDirectoryContainingPackageDotSwift()
     let isValidLocalCustomFile = arguments.xcconfig?.isLocalXCConfigFileValid()
 
-//    guard arguments.url.absoluteString.first != "/" else {
-//      throw CleanExit.message(
-//                """
-//                Error: Invalid argument '--url <url>'
-//                Usage: Absolute paths aren't supported! Please pass a relative path to your local package.
-//                """
-//      )
-//    }
-//
+    guard arguments.url.absoluteString.first != "/" else {
+      throw CleanExit.message(
+                """
+                Error: Invalid argument '--url <url>'
+                Usage: Absolute paths aren't supported! Please pass a relative path to your local package.
+                """
+      )
+    }
+
     guard isValidRemoteURL || isValidLocalDirectory == true else {
       throw CleanExit.message(
                 """

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -118,7 +118,6 @@ struct AllArguments: ParsableArguments {
     ],
     help: """
         A valid relative local directory path that point to a file of type `.xcconfig`
-        - Note: For local packages full paths are discouraged and unsupported.
         """
   )
   var xcconfig: URL? = nil
@@ -160,12 +159,11 @@ extension ParsableCommand {
       )
     }
       
-      if let isValidLocalCustomFile, isValidLocalCustomFile == false {
+      if isValidLocalCustomFile == false {
           throw CleanExit.message(
                     """
                     Error: Invalid argument '--xcconfig <url>'
-                    Usage: The URL must be either:
-                    - A relative local file path that has point to a `.xcconfig` file, e.g. `../other-dir/CustomConfiguration.xcconfig`
+                    Usage: The URL must be a relative local file path that has point to a `.xcconfig` file, e.g. `../other-dir/CustomConfiguration.xcconfig`
                     """
           )
       }

--- a/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderTests.swift
+++ b/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderTests.swift
@@ -33,7 +33,7 @@ final class BinarySizeProviderTests: XCTestCase {
     var lastSwiftPackage: SwiftPackage?
     var lastIsDynamic: Bool?
 
-    defaultSizeMeasurer = { verbose in
+    defaultSizeMeasurer = { xcconfig, verbose in
       lastVerbose = verbose
       defaultSizeMeasurerCallsCount += 1
 
@@ -69,7 +69,8 @@ final class BinarySizeProviderTests: XCTestCase {
             ]
           )
         ]
-      ),
+      ), 
+      xcconfig: nil,
       verbose: true
     )
 

--- a/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
+++ b/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
@@ -100,7 +100,8 @@ final class DependenciesProviderTests: XCTestCase {
           target2,
           target3
         ]
-      ), xcconfig: nil,
+      ),
+      xcconfig: nil,
       verbose: true
     )
 

--- a/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
+++ b/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
@@ -100,7 +100,7 @@ final class DependenciesProviderTests: XCTestCase {
           target2,
           target3
         ]
-      ),
+      ), xcconfig: nil,
       verbose: true
     )
 
@@ -222,7 +222,8 @@ final class DependenciesProviderTests: XCTestCase {
         targets: [
           target
         ]
-      ),
+      ), 
+      xcconfig: nil,
       verbose: true
     )
 

--- a/Tests/AppTests/Providers/PlatformsProvider/PlatformsProviderTests.swift
+++ b/Tests/AppTests/Providers/PlatformsProvider/PlatformsProviderTests.swift
@@ -45,6 +45,7 @@ final class PlatformsProviderTests: XCTestCase {
           ),
         ]
       ),
+      xcconfig: nil,
       verbose: true
     )
 


### PR DESCRIPTION
fix #48 

This pull request enables users to specify a custom XCConfig file, providing enhanced control over how project configuration influences its size.

For instance, by including `--xcconfig test.xcconfig` along with the following file, users can gain insights into the impact of specific settings on project size, such as the generation of `Assets.car`.

```xcconfig
ASSETCATALOG_COMPILER_OPTIMIZATION = space
```

For further information on XCConfig files:
- Apple Developer Documentation: [Adding a Build Configuration File to Your Project](https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project)
- NSHipster: [XCConfig](https://nshipster.com/xcconfig/)