### PR TITLE
Migrate to Async Await and Enable Swift strict concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref }}'
@@ -15,12 +15,11 @@ jobs:
   test:
     name: "Test"
     runs-on: macos-latest
-    if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Check cache for Swift dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,15 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
-
   workflow_dispatch:
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref }}'
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -29,3 +32,11 @@ jobs:
 
       - name: Run tests
         run: swift test --build-path PROJECT_DIR
+
+      - name: Report code coverage
+        uses: codecov/codecov-action@v4
+        timeout-minutes: 10
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          exclude: Tests/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Report code coverage
         uses: codecov/codecov-action@v4
+        continue-on-error: true
         timeout-minutes: 10
         with:
           fail_ci_if_error: true

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-package-info.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-package-info.xcscheme
@@ -191,12 +191,12 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--path https://github.com/firebase/firebase-ios-sdk.git"
+            argument = "binary-size "
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = ""
-            isEnabled = "NO">
+            argument = "--path https://github.com/firebase/firebase-ios-sdk.git"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-v 6.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
       targets: [
         "Run"
       ]
-    )
+    ),
+    .library(name: "SwiftPackageInfo", targets: ["App"])
   ],
   dependencies: [
     // Can't update and benefit from latest Swift 6 warnings fixes because the latest
@@ -155,3 +156,9 @@ let package = Package(
     )
   ]
 )
+
+// TODO: For lib
+// - Extract most out to the `App Target`
+// - Provide API for both a simple struct definition and passing a ready Package(Model)
+// - Remodel de report part, which has to return data for the consumer of the lib
+// - Consider App Target split

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -17,6 +17,8 @@ let package = Package(
     )
   ],
   dependencies: [
+    // Can't update and benefit from latest Swift 6 warnings fixes because the latest
+    // swift-package-manager release still relies on older versions of the swift-argument-parser
     .package(
       url: "https://github.com/apple/swift-argument-parser",
       .upToNextMinor(from: "1.2.1")
@@ -47,12 +49,20 @@ let package = Package(
           name: "ArgumentParser",
           package: "swift-argument-parser"
         ),
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .testTarget(
       name: "RunTests",
       dependencies: [
         .target(name: "Run")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .target(
@@ -67,6 +77,10 @@ let package = Package(
           package: "http_client"
         ),
         .target(name: "Core")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .testTarget(
@@ -74,12 +88,20 @@ let package = Package(
       dependencies: [
         .target(name: "App"),
         .target(name: "CoreTestSupport")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .target(
       name: "Reports",
       dependencies: [
         .target(name: "Core")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .testTarget(
@@ -87,6 +109,10 @@ let package = Package(
       dependencies: [
         .target(name: "Reports"),
         .target(name: "CoreTestSupport")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .target(
@@ -100,6 +126,10 @@ let package = Package(
           name: "SwiftPM",
           package: "swift-package-manager"
         ),
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .testTarget(
@@ -107,12 +137,20 @@ let package = Package(
       dependencies: [
         .target(name: "Core"),
         .target(name: "CoreTestSupport")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     ),
     .target(
       name: "CoreTestSupport",
       dependencies: [
         .target(name: "Core")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("InferSendableFromCaptures"),
       ]
     )
   ]

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -63,7 +63,7 @@ final class AppManager {
 
   init(
     fileManager: FileManager = .default,
-    console: Console = .default,
+    console: Console,
     xcconfig: URL?,
     verbose: Bool
   ) {
@@ -73,9 +73,9 @@ final class AppManager {
     self.verbose = verbose
   }
 
-  func cloneEmptyApp() throws {
+  func cloneEmptyApp() async throws {
     do {
-      try Shell.performShallowGitClone(
+      try await Shell.performShallowGitClone(
         workingDirectory: fileManager.currentDirectoryPath,
         repositoryURLString: "https://github.com/marinofelipe/swift-package-info",
         branchOrTag: "main",
@@ -92,7 +92,7 @@ final class AppManager {
     }
   }
 
-  func generateArchive() throws {
+  func generateArchive() async throws {
     let workingDirectory = fileManager.currentDirectoryPath
     var cmdXCConfig: String = ""
     if let xcconfig, let customXCConfigURL = URL(string: workingDirectory)?.appendingPathComponent(xcconfig.path) {
@@ -114,10 +114,10 @@ final class AppManager {
         """
 
     if verbose {
-      console.lineBreakAndWrite(command)
+      await console.lineBreakAndWrite(command)
     }
 
-    let output = try Shell.run(
+    let output = try await Shell.run(
       command.text,
       workingDirectory: workingDirectory,
       verbose: verbose,
@@ -126,7 +126,7 @@ final class AppManager {
 
     if output.succeeded == false {
       if verbose {
-        console.lineBreakAndWrite(
+        await console.lineBreakAndWrite(
           .init(
             text: "Command failed...",
             color: .red
@@ -139,12 +139,14 @@ final class AppManager {
     }
   }
 
-  func calculateBinarySize() throws -> SizeOnDisk {
+  func calculateBinarySize() async throws -> SizeOnDisk {
     do {
       let url = URL(fileURLWithPath: archivedProductPath)
       let appSize = try url.sizeOnDisk()
 
-      if verbose { console.lineBreakAndWrite(appSize.message) }
+      if verbose {
+        await console.lineBreakAndWrite(appSize.message)
+      }
 
       return appSize
     } catch {

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -142,7 +142,7 @@ final class AppManager {
   func calculateBinarySize() async throws -> SizeOnDisk {
     do {
       let url = URL(fileURLWithPath: archivedProductPath)
-      let appSize = try url.sizeOnDisk()
+      let appSize = try await url.sizeOnDisk()
 
       if verbose {
         await console.lineBreakAndWrite(appSize.message)

--- a/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
+++ b/Sources/App/Providers/BinarySizeProvider/BinarySizeProvider.swift
@@ -61,6 +61,7 @@ enum BinarySizeProviderError: LocalizedError, Equatable {
 }
 
 public struct BinarySizeProvider {
+  @Sendable
   public static func fetchInformation(
     for swiftPackage: SwiftPackage,
     package: PackageWrapper,
@@ -135,7 +136,8 @@ struct BinarySizeInformation: Equatable, Encodable, CustomConsoleMessagesConvert
 }
 
 #if DEBUG
-var defaultSizeMeasurer: (URL?, Bool) async -> SizeMeasuring = { xcconfig, verbose in
+// debug only
+nonisolated(unsafe) var defaultSizeMeasurer: (URL?, Bool) async -> SizeMeasuring = { xcconfig, verbose in
   await SizeMeasurer(verbose: verbose, xcconfig: xcconfig).binarySize
 }
 #else

--- a/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
+++ b/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
@@ -33,6 +33,7 @@ enum DependenciesProviderError: LocalizedError, Equatable {
 }
 
 public struct DependenciesProvider {
+  @Sendable
   public static func fetchInformation(
     for swiftPackage: SwiftPackage,
     package: PackageWrapper,

--- a/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
+++ b/Sources/App/Providers/DependenciesProvider/DependenciesProvider.swift
@@ -38,13 +38,9 @@ public struct DependenciesProvider {
     package: PackageWrapper,
     xcconfig: URL?,
     verbose: Bool
-  ) -> Result<ProvidedInfo, InfoProviderError> {
+  ) async throws -> ProvidedInfo {
     guard let product = package.products.first(where: { $0.name == swiftPackage.product }) else {
-      return .failure(
-        .init(
-          localizedError: DependenciesProviderError.failedToMatchProduct
-        )
-      )
+      throw DependenciesProviderError.failedToMatchProduct
     }
 
     let productTargets = product.targets
@@ -53,12 +49,10 @@ public struct DependenciesProvider {
       package: package
     )
 
-    return .success(
-      .init(
-        providerName: "Dependencies",
-        providerKind: .dependencies,
-        information: DependenciesInformation(dependencies: externalDependencies)
-      )
+    return ProvidedInfo(
+      providerName: "Dependencies",
+      providerKind: .dependencies,
+      information: DependenciesInformation(dependencies: externalDependencies)
     )
   }
 
@@ -132,14 +126,14 @@ struct DependenciesInformation: Equatable, CustomConsoleMessagesConvertible {
 
   private func buildConsoleMessages() -> [ConsoleMessage] {
     if dependencies.isEmpty {
-      return [
+      [
         .init(
           text: "No third-party dependencies :)",
           hasLineBreakAfter: false
         )
       ]
     } else {
-      return consoleDependencies.enumerated().map { index, dependency -> [ConsoleMessage] in
+      consoleDependencies.enumerated().map { index, dependency -> [ConsoleMessage] in
         var messages: [ConsoleMessage] = [
           .init(
             text: "\(dependency.product)",

--- a/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
+++ b/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
@@ -22,6 +22,7 @@ import Core
 import Foundation
 
 public struct PlatformsProvider {
+  @Sendable
   public static func fetchInformation(
     for swiftPackage: SwiftPackage,
     package: PackageWrapper,

--- a/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
+++ b/Sources/App/Providers/PlatformsProvider/PlatformsProvider.swift
@@ -27,14 +27,12 @@ public struct PlatformsProvider {
     package: PackageWrapper,
     xcconfig: URL?,
     verbose: Bool
-  ) -> Result<ProvidedInfo, InfoProviderError> {
-    .success(
-      .init(
-        providerName: "Platforms",
-        providerKind: .platforms,
-        information: PlatformsInformation(
-          platforms: package.platforms
-        )
+  ) async throws -> ProvidedInfo {
+    .init(
+      providerName: "Platforms",
+      providerKind: .platforms,
+      information: PlatformsInformation(
+        platforms: package.platforms
       )
     )
   }
@@ -63,14 +61,14 @@ struct PlatformsInformation: Equatable, Encodable, CustomConsoleMessagesConverti
 
   private func buildConsoleMessages() -> [ConsoleMessage] {
     if platforms.isEmpty {
-      return [
+      [
         .init(
           text: "System default",
           hasLineBreakAfter: false
         )
       ]
     } else {
-      return platforms
+      platforms
         .map { platform -> [ConsoleMessage] in
           var messages = [
             ConsoleMessage(

--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -84,12 +84,12 @@ public final class SwiftPackageService {
     swiftPackage: SwiftPackage,
     verbose: Bool
   ) async throws -> SwiftPackageValidationResult {
-    Console.default.lineBreakAndWrite("swift-package-info built with Swift Toolchain: \(ToolsVersion.current)")
+    await Console.default.lineBreakAndWrite("swift-package-info built with Swift Toolchain: \(ToolsVersion.current)")
 
-    let swiftVersionOutput = try Shell.run("xcrun swift -version", verbose: false)
-    let swiftVersion = String(data: swiftVersionOutput.data, encoding: .utf8)
+    let swiftVersionOutput = try await Shell.run("xcrun swift -version", verbose: false)
+    let swiftVersion = String(data: swiftVersionOutput.data, encoding: .utf8) ?? "<undefined>"
 
-    Console.default.write("Current user Swift Toolchain: \(swiftVersion ?? "")")
+    await Console.default.write("Current user Swift Toolchain: \(swiftVersion)")
 
     if swiftPackage.isLocal {
       return try await runLocalValidation(for: swiftPackage, verbose: verbose)

--- a/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
+++ b/Sources/App/Services/SwiftPackageService/SwiftPackageService.swift
@@ -26,8 +26,8 @@ import HTTPClientCore
 
 import Basics
 import PackageModel
-import SourceControl
-import TSCBasic
+@preconcurrency import SourceControl
+@preconcurrency import TSCBasic
 import TSCUtility
 
 public struct SwiftPackageValidationResult {
@@ -199,7 +199,8 @@ public final class SwiftPackageService {
       ) { result in
         switch result {
         case let .success(handle):
-          continuation.resume(returning: handle)
+          let handleCopy = handle
+          continuation.resume(returning: handleCopy)
         case let .failure(error):
           continuation.resume(throwing: error)
         }

--- a/Sources/App/SwiftPackage+Validate.swift
+++ b/Sources/App/SwiftPackage+Validate.swift
@@ -1,0 +1,83 @@
+//
+//  SwiftPackage+Validate.swift
+//  swift-package-info
+//
+//  Created by Marino Felipe on 30.01.25.
+//
+
+import Core
+
+import PackageModel
+
+enum SwiftPackageValidationError: Error {
+  case invalidURL
+  case failedToLoadPackage
+  case noProductFound
+}
+
+extension SwiftPackage {
+  mutating func validate(
+    swiftPackageService: SwiftPackageService = SwiftPackageService(),
+    isVerbose: Bool = false,
+    console: Console? = nil // only available on CLI
+  ) async throws(SwiftPackageValidationError) -> Package {
+    let packageResponse: SwiftPackageValidationResult
+    do {
+      packageResponse = try await swiftPackageService.validate(
+        swiftPackage: self,
+        verbose: isVerbose
+      )
+    } catch {
+      throw .failedToLoadPackage
+    }
+
+    switch packageResponse.sourceInformation {
+    case let .remote(isRepositoryValid, tagState, latestTag):
+      guard isRepositoryValid else {
+//        throw CleanExit.message(
+//          """
+//          Error: Invalid argument '--url <url>'
+//          Usage: The URL must be a valid git repository URL that contains
+//          a `Package.swift`, e.g `https://github.com/Alamofire/Alamofire`
+//          """
+//        )
+        throw SwiftPackageValidationError.invalidURL
+      }
+
+      switch self.resolution {
+      case let .revision(revision):
+        await console?.lineBreakAndWrite("Resolved revision: \(revision)")
+      case .version:
+        switch tagState {
+        case .undefined, .invalid:
+          await console?.lineBreakAndWrite("Package version was \(tagState.description)")
+
+          if let latestTag {
+            await console?.lineBreakAndWrite("Defaulting to latest found semver tag: \(latestTag)")
+            self.resolution = .version(latestTag)
+          }
+        case .valid:
+          break
+        }
+      }
+    case .local:
+      break
+    }
+
+    guard let firstProduct = packageResponse.availableProducts.first else {
+//      throw CleanExit.message(
+//        "Error: \(swiftPackage.url) doesn't contain any product declared on Package.swift"
+//      )
+      throw .noProductFound
+    }
+
+    if packageResponse.isProductValid == false {
+      await console?.lineBreakAndWrite("Invalid product: \(self.product)")
+      await console?.lineBreakAndWrite("Using first found product instead: \(firstProduct)")
+
+      self.product = firstProduct
+    }
+
+    return packageResponse.package
+  }
+}

--- a/Sources/Core/Console.swift
+++ b/Sources/Core/Console.swift
@@ -7,12 +7,12 @@
 //  Created by Marino Felipe on 28.12.20.
 //
 
-import TSCBasic
+@preconcurrency import TSCBasic
 import TSCUtility
 
 // MARK: - ConsoleColor - Wrapper
 
-public enum ConsoleColor {
+public enum ConsoleColor: Sendable {
   case noColor
   case red
   case green
@@ -76,7 +76,7 @@ final class PrintController: TerminalControlling {
 
 // MARK: - ConsoleMessage
 
-public struct ConsoleMessage: Equatable, ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
+public struct ConsoleMessage: Equatable, ExpressibleByStringLiteral, ExpressibleByStringInterpolation, Sendable {
   public let text: String
   let color: ConsoleColor
   let isBold: Bool
@@ -117,7 +117,7 @@ public protocol CustomConsoleMessageConvertible {
   var message: ConsoleMessage { get }
 }
 
-public protocol CustomConsoleMessagesConvertible {
+public protocol CustomConsoleMessagesConvertible: Sendable {
   /// A console message representation that is split into and composed by multiple messages.
   var messages: [ConsoleMessage] { get }
 }
@@ -132,7 +132,7 @@ public final class Console {
 
   public init(
     isOutputColored: Bool,
-    terminalController: TerminalControlling = TerminalControllerFactory.make(stream: stdoutStream),
+    terminalController: TerminalControlling = TerminalControllerFactory.make(),
     progressAnimation: ProgressAnimationProtocol = NinjaProgressAnimation(stream: stdoutStream)
   ) {
     self.isOutputColored = isOutputColored

--- a/Sources/Core/Console.swift
+++ b/Sources/Core/Console.swift
@@ -13,206 +13,207 @@ import TSCUtility
 // MARK: - ConsoleColor - Wrapper
 
 public enum ConsoleColor {
-    case noColor
-    case red
-    case green
-    case yellow
-    case cyan
-    case white
-    case black
-    case gray
+  case noColor
+  case red
+  case green
+  case yellow
+  case cyan
+  case white
+  case black
+  case gray
 }
 
 private extension ConsoleColor {
-    var terminalColor: TerminalController.Color {
-        switch self {
-            case .black: return .black
-            case .cyan: return .cyan
-            case .green: return .green
-            case .gray: return .gray
-            case .noColor: return .noColor
-            case .red: return .red
-            case .white: return .white
-            case .yellow: return .yellow
-        }
+  var terminalColor: TerminalController.Color {
+    switch self {
+    case .black: return .black
+    case .cyan: return .cyan
+    case .green: return .green
+    case .gray: return .gray
+    case .noColor: return .noColor
+    case .red: return .red
+    case .white: return .white
+    case .yellow: return .yellow
     }
+  }
 }
 
 // MARK: - TerminalControlling
 
 public protocol TerminalControlling {
-    func endLine()
-    func write(
-        _ string: String,
-        inColor _: ConsoleColor,
-        bold: Bool
-    )
+  func endLine()
+  func write(
+    _ string: String,
+    inColor _: ConsoleColor,
+    bold: Bool
+  )
 }
 
 extension TerminalController: TerminalControlling {
-    public func write(
-        _ string: String,
-        inColor color: ConsoleColor,
-        bold: Bool
-    ) {
-        write(
-            string,
-            inColor: color.terminalColor,
-            bold: bold
-        )
-    }
+  public func write(
+    _ string: String,
+    inColor color: ConsoleColor,
+    bold: Bool
+  ) {
+    write(
+      string,
+      inColor: color.terminalColor,
+      bold: bold
+    )
+  }
 }
 
 final class PrintController: TerminalControlling {
-    func endLine() {
-        print()
-    }
+  func endLine() {
+    print()
+  }
 
-    func write(_ string: String, inColor _: ConsoleColor, bold: Bool) {
-        print(string)
-    }
+  func write(_ string: String, inColor _: ConsoleColor, bold: Bool) {
+    print(string)
+  }
 
 }
 
 // MARK: - ConsoleMessage
 
 public struct ConsoleMessage: Equatable, ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
-    public let text: String
-    let color: ConsoleColor
-    let isBold: Bool
-    let hasLineBreakAfter: Bool
+  public let text: String
+  let color: ConsoleColor
+  let isBold: Bool
+  let hasLineBreakAfter: Bool
 
-    public init(
-        text: String,
-        color: ConsoleColor,
-        isBold: Bool = false,
-        hasLineBreakAfter: Bool = true
-    ) {
-        self.text = text
-        self.color = color
-        self.isBold = isBold
-        self.hasLineBreakAfter = hasLineBreakAfter
-    }
+  public init(
+    text: String,
+    color: ConsoleColor,
+    isBold: Bool = false,
+    hasLineBreakAfter: Bool = true
+  ) {
+    self.text = text
+    self.color = color
+    self.isBold = isBold
+    self.hasLineBreakAfter = hasLineBreakAfter
+  }
 
-    public init(
-        text: String,
-        isBold: Bool = false,
-        hasLineBreakAfter: Bool = true
-    ) {
-        self.text = text
-        self.color = .noColor
-        self.isBold = isBold
-        self.hasLineBreakAfter = hasLineBreakAfter
-    }
+  public init(
+    text: String,
+    isBold: Bool = false,
+    hasLineBreakAfter: Bool = true
+  ) {
+    self.text = text
+    self.color = .noColor
+    self.isBold = isBold
+    self.hasLineBreakAfter = hasLineBreakAfter
+  }
 
-    public init(stringLiteral value: String) {
-        self.init(text: value, color: .noColor, isBold: false, hasLineBreakAfter: true)
-    }
+  public init(stringLiteral value: String) {
+    self.init(text: value, color: .noColor, isBold: false, hasLineBreakAfter: true)
+  }
 }
 
 // MARK: - CustomConsoleMessageConvertible
 
 public protocol CustomConsoleMessageConvertible {
-    /// A console message representation.
-    var message: ConsoleMessage { get }
+  /// A console message representation.
+  var message: ConsoleMessage { get }
 }
 
 public protocol CustomConsoleMessagesConvertible {
-    /// A console message representation that is split into and composed by multiple messages.
-    var messages: [ConsoleMessage] { get }
+  /// A console message representation that is split into and composed by multiple messages.
+  var messages: [ConsoleMessage] { get }
 }
 
 // MARK: - Console
 
+@MainActor
 public final class Console {
-    private var isOutputColored: Bool
-    private let terminalController: TerminalControlling
-    private let progressAnimation: ProgressAnimationProtocol
+  private var isOutputColored: Bool
+  private let terminalController: TerminalControlling
+  private let progressAnimation: ProgressAnimationProtocol
 
-    public init(
-        isOutputColored: Bool,
-        terminalController: TerminalControlling = TerminalControllerFactory.make(stream: stdoutStream),
-        progressAnimation: ProgressAnimationProtocol = NinjaProgressAnimation(stream: stdoutStream)
-    ) {
-        self.isOutputColored = isOutputColored
-        self.terminalController = terminalController
-        self.progressAnimation = progressAnimation
-    }
+  public init(
+    isOutputColored: Bool,
+    terminalController: TerminalControlling = TerminalControllerFactory.make(stream: stdoutStream),
+    progressAnimation: ProgressAnimationProtocol = NinjaProgressAnimation(stream: stdoutStream)
+  ) {
+    self.isOutputColored = isOutputColored
+    self.terminalController = terminalController
+    self.progressAnimation = progressAnimation
+  }
 
-    public func write(_ message: ConsoleMessage) {
-        write(
-            message: message.text,
-            color: isOutputColored ? message.color : .noColor,
-            bold: message.isBold,
-            addLineBreakAfter: message.hasLineBreakAfter
-        )
-    }
+  public func write(_ message: ConsoleMessage) {
+    write(
+      message: message.text,
+      color: isOutputColored ? message.color : .noColor,
+      bold: message.isBold,
+      addLineBreakAfter: message.hasLineBreakAfter
+    )
+  }
 
-    public func lineBreakAndWrite(_ message: ConsoleMessage) {
-        lineBreak()
-        write(
-            message: message.text,
-            color: isOutputColored ? message.color : .noColor,
-            bold: message.isBold,
-            addLineBreakAfter: message.hasLineBreakAfter
-        )
-    }
+  public func lineBreakAndWrite(_ message: ConsoleMessage) {
+    lineBreak()
+    write(
+      message: message.text,
+      color: isOutputColored ? message.color : .noColor,
+      bold: message.isBold,
+      addLineBreakAfter: message.hasLineBreakAfter
+    )
+  }
 
-    public func lineBreak() {
-        terminalController.endLine()
-    }
+  public func lineBreak() {
+    terminalController.endLine()
+  }
 }
 
 public final class TerminalControllerFactory {
-    public static func make(stream: WritableByteStream = stdoutStream) -> TerminalControlling {
-        if let controller = TerminalController(stream: stream) {
-            return controller
-        } else {
-            return PrintController()
-        }
+  public static func make(stream: WritableByteStream = stdoutStream) -> TerminalControlling {
+    if let controller = TerminalController(stream: stream) {
+      return controller
+    } else {
+      return PrintController()
     }
+  }
 }
 
 // MARK: - Loading
 
 public extension Console {
-    func showLoading(
-        step: Int ,
-        total: Int = 10,
-        text: String
-    ) {
-        progressAnimation.update(
-            step: step,
-            total: total,
-            text: text
-        )
-    }
+  func showLoading(
+    step: Int ,
+    total: Int = 10,
+    text: String
+  ) {
+    progressAnimation.update(
+      step: step,
+      total: total,
+      text: text
+    )
+  }
 
-    func completeLoading(success: Bool) {
-        progressAnimation.complete(success: success)
-    }
+  func completeLoading(success: Bool) {
+    progressAnimation.complete(success: success)
+  }
 }
 
 // MARK: - Private
 
 private extension Console {
-    func write(
-        message: String,
-        color: ConsoleColor,
-        bold: Bool,
-        addLineBreakAfter: Bool
-    ) {
-        terminalController.write(message, inColor: color, bold: bold)
-        if addLineBreakAfter { self.lineBreak() }
-    }
+  func write(
+    message: String,
+    color: ConsoleColor,
+    bold: Bool,
+    addLineBreakAfter: Bool
+  ) {
+    terminalController.write(message, inColor: color, bold: bold)
+    if addLineBreakAfter { self.lineBreak() }
+  }
 }
 
 #if DEBUG
 extension Console {
-    public static var `default` = Console(isOutputColored: false)
+  public static var `default` = Console(isOutputColored: false)
 }
 #else
 extension Console {
-    public static let `default` = Console(isOutputColored: true)
+  public static let `default` = Console(isOutputColored: true)
 }
 #endif

--- a/Sources/Core/Extensions/AbsolutePath+Core.swift
+++ b/Sources/Core/Extensions/AbsolutePath+Core.swift
@@ -35,7 +35,8 @@ public extension AbsolutePath {
 }
 
 #if DEBUG
-  var currentDirPath = FileManager.default.currentDirectoryPath
+  //debug only
+  nonisolated(unsafe) var currentDirPath = FileManager.default.currentDirectoryPath
 #else
   let currentDirPath = FileManager.default.currentDirectoryPath
 #endif

--- a/Sources/Core/Extensions/ExpressibleByArgument+Core.swift
+++ b/Sources/Core/Extensions/ExpressibleByArgument+Core.swift
@@ -21,7 +21,7 @@
 import ArgumentParser
 import Foundation
 
-extension URL: ExpressibleByArgument {
+extension URL: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(string: argument)
     }

--- a/Sources/Core/Extensions/URL+Core.swift
+++ b/Sources/Core/Extensions/URL+Core.swift
@@ -12,91 +12,92 @@ import Foundation
 // MARK: - Size on disk
 
 extension URL {
-    // MARK: Public
+  // MARK: Public
 
-    public static let fileByteCountFormatter: ByteCountFormatter = {
-        let byteCountFormatter = ByteCountFormatter()
-        byteCountFormatter.countStyle = .file
-        return byteCountFormatter
-    }()
+  nonisolated(unsafe) public static let fileByteCountFormatter: ByteCountFormatter = {
+    let byteCountFormatter = ByteCountFormatter()
+    byteCountFormatter.countStyle = .file
+    return byteCountFormatter
+  }()
 
-    public func sizeOnDisk() throws -> SizeOnDisk {
-        let size = try isDirectory()
-            ? try directoryTotalAllocatedSize(includingSubfolders: true)
-            : try totalFileAllocatedSize()
+  @MainActor
+  public func sizeOnDisk() throws -> SizeOnDisk {
+    let size = try isDirectory()
+    ? try directoryTotalAllocatedSize(includingSubfolders: true)
+    : try totalFileAllocatedSize()
 
-        guard let formattedByteCount = URL.fileByteCountFormatter.string(for: size) else {
-            throw URLSizeReadingError.unableToCountCountBytes(filePath: self.path)
-        }
-        return .init(amount: size, formatted: formattedByteCount)
+    guard let formattedByteCount = URL.fileByteCountFormatter.string(for: size) else {
+      throw URLSizeReadingError.unableToCountCountBytes(filePath: self.path)
+    }
+    return .init(amount: size, formatted: formattedByteCount)
+  }
+
+  // MARK: Internal
+
+  func totalFileAllocatedSize() throws -> Int {
+    try resourceValues(forKeys: [.totalFileAllocatedSizeKey]).totalFileAllocatedSize ?? 0
+  }
+
+  func directoryTotalAllocatedSize(
+    fileManager: FileManager = .default,
+    includingSubfolders: Bool = false
+  ) throws -> Int {
+    let allocatedSizeWithoutSubfolders = {
+      return try fileManager.contentsOfDirectory(at: self, includingPropertiesForKeys: nil).totalAllocatedSize()
     }
 
-    // MARK: Internal
-
-    func totalFileAllocatedSize() throws -> Int {
-        try resourceValues(forKeys: [.totalFileAllocatedSizeKey]).totalFileAllocatedSize ?? 0
-    }
-
-    func directoryTotalAllocatedSize(
-        fileManager: FileManager = .default,
-        includingSubfolders: Bool = false
-    ) throws -> Int {
-        let allocatedSizeWithoutSubfolders = {
-            return try fileManager.contentsOfDirectory(at: self, includingPropertiesForKeys: nil).totalAllocatedSize()
-        }
-
-        if includingSubfolders {
-            guard let urls = fileManager.enumerator(at: self, includingPropertiesForKeys: nil)?.allObjects as? [URL] else {
-                return try allocatedSizeWithoutSubfolders()
-            }
-
-            return try urls.totalAllocatedSize()
-        }
-
+    if includingSubfolders {
+      guard let urls = fileManager.enumerator(at: self, includingPropertiesForKeys: nil)?.allObjects as? [URL] else {
         return try allocatedSizeWithoutSubfolders()
+      }
+
+      return try urls.totalAllocatedSize()
     }
 
-    func isDirectory() throws -> Bool {
-        try resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
-    }
+    return try allocatedSizeWithoutSubfolders()
+  }
+
+  func isDirectory() throws -> Bool {
+    try resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
+  }
 }
 
 enum URLSizeReadingError: LocalizedError {
-    case unableToCountCountBytes(filePath: String)
+  case unableToCountCountBytes(filePath: String)
 
-    var errorDescription: String? {
-        switch self {
-            case let .unableToCountCountBytes(filePath):
-                return "Unable to count bytes for file at: \(filePath)"
-        }
+  var errorDescription: String? {
+    switch self {
+    case let .unableToCountCountBytes(filePath):
+      return "Unable to count bytes for file at: \(filePath)"
     }
+  }
 }
 
 extension Array where Element == URL {
-    func totalAllocatedSize() throws -> Int {
-        try lazy.reduce(0) { try $1.totalFileAllocatedSize() + $0 }
-    }
+  func totalAllocatedSize() throws -> Int {
+    try lazy.reduce(0) { try $1.totalFileAllocatedSize() + $0 }
+  }
 }
 
 // MARK: - Extension - Local & remote
 
 public extension URL {
-    static let isValidURLRegex = "^(https?://)?(www\\.)?([-a-z0-9]{1,63}\\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\\.[a-z]{2,6}(/[-\\w@\\+\\.~#\\?&/=%]*)?$"
-    
-    var isValidRemote: Bool {
-        NSPredicate(format:"SELF MATCHES %@", Self.isValidURLRegex)
-            .evaluate(with: absoluteString)
-    }
-    
-    func isLocalDirectoryContainingPackageDotSwift(
-        fileManager: FileManager = .default
-    ) throws -> Bool {
-        try fileManager.contentsOfDirectory(atPath: path).contains("Package.swift")
-    }
-    
-    func isLocalXCConfigFileValid(
-        fileManager: FileManager = .default
-    ) -> Bool {
-        fileManager.isReadableFile(atPath: path) && self.pathExtension == "xcconfig"
-    }
+  static let isValidURLRegex = "^(https?://)?(www\\.)?([-a-z0-9]{1,63}\\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\\.[a-z]{2,6}(/[-\\w@\\+\\.~#\\?&/=%]*)?$"
+
+  var isValidRemote: Bool {
+    NSPredicate(format:"SELF MATCHES %@", Self.isValidURLRegex)
+      .evaluate(with: absoluteString)
+  }
+
+  func isLocalDirectoryContainingPackageDotSwift(
+    fileManager: FileManager = .default
+  ) throws -> Bool {
+    try fileManager.contentsOfDirectory(atPath: path).contains("Package.swift")
+  }
+
+  func isLocalXCConfigFileValid(
+    fileManager: FileManager = .default
+  ) -> Bool {
+    fileManager.isReadableFile(atPath: path) && self.pathExtension == "xcconfig"
+  }
 }

--- a/Sources/Core/InfoProvider.swift
+++ b/Sources/Core/InfoProvider.swift
@@ -42,7 +42,7 @@ public enum ProviderKind: String, CodingKey {
   case platforms
 }
 
-public typealias InfoProvider = (
+public typealias InfoProvider = @Sendable (
   _ swiftPackage: SwiftPackage,
   _ packageContent: PackageWrapper,
   _ xcconfig: URL?,
@@ -50,14 +50,14 @@ public typealias InfoProvider = (
 ) async throws -> ProvidedInfo
 //throws(InfoProviderError) , typed throws only supported from macOS 15.0 runtime
 
-public struct ProvidedInfo: Encodable, CustomConsoleMessagesConvertible {
+public struct ProvidedInfo: Encodable, CustomConsoleMessagesConvertible, Sendable {
   public let providerName: String
   public let providerKind: ProviderKind
   public var messages: [ConsoleMessage] {
     informationMessagesConvertible.messages
   }
   
-  private let informationEncoder: (Encoder) throws -> Void
+  private let informationEncoder: @Sendable (Encoder) throws -> Void
   private let informationMessagesConvertible: CustomConsoleMessagesConvertible
   
   public init<T>(

--- a/Sources/Core/InfoProvider.swift
+++ b/Sources/Core/InfoProvider.swift
@@ -21,59 +21,60 @@
 import Foundation
 
 public struct InfoProviderError: Error, CustomConsoleMessageConvertible {
-    public let message: ConsoleMessage
-
-    public init(
-        localizedError: LocalizedError,
-        customConsoleMessage: ConsoleMessage? = nil
-    ) {
-        self.message = customConsoleMessage ?? .init(
-            text: localizedError.errorDescription ?? "",
-            color: .red,
-            isBold: true,
-            hasLineBreakAfter: true
-        )
-    }
+  public let message: ConsoleMessage
+  
+  public init(
+    localizedError: LocalizedError,
+    customConsoleMessage: ConsoleMessage? = nil
+  ) {
+    self.message = customConsoleMessage ?? .init(
+      text: localizedError.errorDescription ?? "",
+      color: .red,
+      isBold: true,
+      hasLineBreakAfter: true
+    )
+  }
 }
 
 public enum ProviderKind: String, CodingKey {
-    case binarySize
-    case dependencies
-    case platforms
+  case binarySize
+  case dependencies
+  case platforms
 }
 
 public typealias InfoProvider = (
-    _ swiftPackage: SwiftPackage,
-    _ packageContent: PackageWrapper,
-    _ xcconfig: URL?,
-    _ verbose: Bool
-) -> Result<ProvidedInfo, InfoProviderError>
+  _ swiftPackage: SwiftPackage,
+  _ packageContent: PackageWrapper,
+  _ xcconfig: URL?,
+  _ verbose: Bool
+) async throws -> ProvidedInfo
+//throws(InfoProviderError) , typed throws only supported from macOS 15.0 runtime
 
 public struct ProvidedInfo: Encodable, CustomConsoleMessagesConvertible {
-    public let providerName: String
-    public let providerKind: ProviderKind
-    public var messages: [ConsoleMessage] {
-        informationMessagesConvertible.messages
+  public let providerName: String
+  public let providerKind: ProviderKind
+  public var messages: [ConsoleMessage] {
+    informationMessagesConvertible.messages
+  }
+  
+  private let informationEncoder: (Encoder) throws -> Void
+  private let informationMessagesConvertible: CustomConsoleMessagesConvertible
+  
+  public init<T>(
+    providerName: String,
+    providerKind: ProviderKind,
+    information: T
+  ) where T: Encodable, T: CustomConsoleMessagesConvertible {
+    self.providerName = providerName
+    self.providerKind = providerKind
+    self.informationMessagesConvertible = information
+    self.informationEncoder = { encoder in
+      var container = encoder.singleValueContainer()
+      try container.encode(information)
     }
-
-    private let informationEncoder: (Encoder) throws -> Void
-    private let informationMessagesConvertible: CustomConsoleMessagesConvertible
-
-    public init<T>(
-        providerName: String,
-        providerKind: ProviderKind,
-        information: T
-    ) where T: Encodable, T: CustomConsoleMessagesConvertible {
-        self.providerName = providerName
-        self.providerKind = providerKind
-        self.informationMessagesConvertible = information
-        self.informationEncoder = { encoder in
-            var container = encoder.singleValueContainer()
-            try container.encode(information)
-        }
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        try informationEncoder(encoder)
-    }
+  }
+  
+  public func encode(to encoder: Encoder) throws {
+    try informationEncoder(encoder)
+  }
 }

--- a/Sources/Core/Models/PackageModel.swift
+++ b/Sources/Core/Models/PackageModel.swift
@@ -22,16 +22,16 @@ import PackageModel
 
 /// A wrapper over SwiftPM library Package type.
 /// `Equatable` and `easily testable`
-public struct PackageWrapper: Equatable {
-  public struct Product: Equatable {
+public struct PackageWrapper: Equatable, Sendable {
+  public struct Product: Equatable, Sendable {
     public let name: String
     public let package: String?
     public let isDynamicLibrary: Bool?
     public let targets: [Target]
   }
 
-  public struct Target: Equatable {
-    public enum Dependency: Equatable {
+  public struct Target: Equatable, Sendable {
+    public enum Dependency: Equatable, Sendable {
       case target(Target)
       case product(Product)
 
@@ -58,7 +58,7 @@ public struct PackageWrapper: Equatable {
     public let dependencies: [Dependency]
   }
 
-  public struct Platform: Equatable {
+  public struct Platform: Equatable, Sendable {
     public let platformName: String
     public let version: String
   }

--- a/Sources/Core/Models/SizeOnDisk.swift
+++ b/Sources/Core/Models/SizeOnDisk.swift
@@ -20,63 +20,63 @@
 
 import Foundation
 
-public struct SizeOnDisk: Equatable {
-    /// Literal size quantity, in `Kilobytes`
-    public let amount: Int
-    public let formatted: String
+public struct SizeOnDisk: Equatable, Sendable {
+  /// Literal size quantity, in `Kilobytes`
+  public let amount: Int
+  public let formatted: String
 
-    public init(
-        amount: Int,
-        formatted: String
-    ) {
-        self.amount = amount
-        self.formatted = formatted
-    }
+  public init(
+    amount: Int,
+    formatted: String
+  ) {
+    self.amount = amount
+    self.formatted = formatted
+  }
 
-    public static let empty: SizeOnDisk = .init(
-        amount: 0,
-        formatted: "0.0"
-    )
+  public static let empty: SizeOnDisk = .init(
+    amount: 0,
+    formatted: "0.0"
+  )
 }
 
 extension SizeOnDisk: CustomStringConvertible {
-    public var description: String {
-        "Size on disk: \(formatted)"
-    }
+  public var description: String {
+    "Size on disk: \(formatted)"
+  }
 }
 
 extension SizeOnDisk: CustomConsoleMessageConvertible {
-    public var message: ConsoleMessage {
-        .init(
-            text: description,
-            color: .yellow,
-            isBold: false
-        )
-    }
+  public var message: ConsoleMessage {
+    .init(
+      text: description,
+      color: .yellow,
+      isBold: false
+    )
+  }
 }
 
 extension SizeOnDisk: AdditiveArithmetic {
-    public static var zero: SizeOnDisk = .empty
+  public static let zero: SizeOnDisk = .empty
 
-    public static func - (lhs: SizeOnDisk, rhs: SizeOnDisk) -> SizeOnDisk {
-        let finalAmount = lhs.amount - rhs.amount
+  public static func - (lhs: SizeOnDisk, rhs: SizeOnDisk) -> SizeOnDisk {
+    let finalAmount = lhs.amount - rhs.amount
 
-        return .init(
-            amount: finalAmount,
-            formatted: URL.fileByteCountFormatter.string(
-                for: finalAmount
-            ) ?? ""
-        )
-    }
+    return .init(
+      amount: finalAmount,
+      formatted: URL.fileByteCountFormatter.string(
+        for: finalAmount
+      ) ?? ""
+    )
+  }
 
-    public static func + (lhs: SizeOnDisk, rhs: SizeOnDisk) -> SizeOnDisk {
-        let finalAmount = lhs.amount + rhs.amount
+  public static func + (lhs: SizeOnDisk, rhs: SizeOnDisk) -> SizeOnDisk {
+    let finalAmount = lhs.amount + rhs.amount
 
-        return .init(
-            amount: finalAmount,
-            formatted: URL.fileByteCountFormatter.string(
-                for: finalAmount
-            ) ?? ""
-        )
-    }
+    return .init(
+      amount: finalAmount,
+      formatted: URL.fileByteCountFormatter.string(
+        for: finalAmount
+      ) ?? ""
+    )
+  }
 }

--- a/Sources/Core/Models/SwiftPackage.swift
+++ b/Sources/Core/Models/SwiftPackage.swift
@@ -20,8 +20,8 @@
 
 import struct Foundation.URL
 
-public struct SwiftPackage: Equatable, CustomStringConvertible {
-  public enum Resolution: Equatable, CustomStringConvertible {
+public struct SwiftPackage: Equatable, CustomStringConvertible, Sendable {
+  public enum Resolution: Equatable, CustomStringConvertible, Sendable {
     case version(String)
     case revision(String)
 

--- a/Sources/Core/PackageLoader.swift
+++ b/Sources/Core/PackageLoader.swift
@@ -26,9 +26,9 @@ import Workspace
 /// Loads the content of a Package.swift, the dependency graph included
 ///
 /// The ``PackageLoader`` uses the SPM library to load the package representation
-public struct PackageLoader {
+public struct PackageLoader: Sendable {
   /// Loads a Package.swift at a given `packagePath`
-  public var load: (AbsolutePath) async throws -> Package
+  public var load: @Sendable (AbsolutePath) async throws -> Package
 }
 
 extension PackageLoader {

--- a/Sources/Core/Shell.swift
+++ b/Sources/Core/Shell.swift
@@ -21,222 +21,217 @@
 import Foundation
 
 public enum Shell {
-    public struct Output: Equatable {
-        public let succeeded: Bool
-        public let data: Data
-        public let errorData: Data
+  public struct Output: Equatable {
+    public let succeeded: Bool
+    public let data: Data
+    public let errorData: Data
+  }
+
+  @discardableResult
+  public static func run(
+    workingDirectory: String? = FileManager.default.currentDirectoryPath,
+    outputPipe: Pipe = .init(),
+    errorPipe: Pipe = .init(),
+    arguments: String...,
+    verbose: Bool,
+    timeout: TimeInterval? = 30
+  ) async throws -> Output {
+    try await runProcess(
+      workingDirectory: workingDirectory,
+      outputPipe: outputPipe,
+      errorPipe: errorPipe,
+      arguments: arguments,
+      verbose: verbose,
+      timeout: timeout
+    )
+  }
+
+  @discardableResult
+  public static func run(
+    _ command: String,
+    outputPipe: Pipe = .init(),
+    errorPipe: Pipe = .init(),
+    workingDirectory: String? = FileManager.default.currentDirectoryPath,
+    verbose: Bool,
+    timeout: TimeInterval? = 30
+  ) async throws -> Output {
+    let commands = command.split(whereSeparator: \.isWhitespace)
+
+    let arguments: [String]
+    if commands.count > 1 {
+      arguments = commands.map { String($0) }
+    } else {
+      arguments = command
+        .split { [" -", " --"].contains(String($0)) }
+        .map { String($0) }
     }
 
-    @discardableResult
-    public static func run(
-        workingDirectory: String? = FileManager.default.currentDirectoryPath,
-        outputPipe: Pipe = .init(),
-        errorPipe: Pipe = .init(),
-        arguments: String...,
-        verbose: Bool,
-        timeout: TimeInterval? = 30
-    ) throws -> Output {
-        try runProcess(
-            workingDirectory: workingDirectory,
-            outputPipe: outputPipe,
-            errorPipe: errorPipe,
-            arguments: arguments,
-            verbose: verbose,
-            timeout: timeout
-        )
-    }
-
-    @discardableResult
-    public static func run(
-        _ command: String,
-        outputPipe: Pipe = .init(),
-        errorPipe: Pipe = .init(),
-        workingDirectory: String? = FileManager.default.currentDirectoryPath,
-        verbose: Bool,
-        timeout: TimeInterval? = 30
-    ) throws -> Output {
-        let commands = command.split(whereSeparator: \.isWhitespace)
-
-        let arguments: [String]
-        if commands.count > 1 {
-            arguments = commands.map { String($0) }
-        } else {
-            arguments = command
-                .split { [" -", " --"].contains(String($0)) }
-                .map { String($0) }
-        }
-
-        return try runProcess(
-            workingDirectory: workingDirectory,
-            outputPipe: outputPipe,
-            errorPipe: errorPipe,
-            arguments: arguments,
-            verbose: verbose,
-            timeout: timeout
-        )
-    }
+    return try await runProcess(
+      workingDirectory: workingDirectory,
+      outputPipe: outputPipe,
+      errorPipe: errorPipe,
+      arguments: arguments,
+      verbose: verbose,
+      timeout: timeout
+    )
+  }
 }
 
 public extension Shell {
-    @discardableResult
-    static func performShallowGitClone(
-        workingDirectory: String? = FileManager.default.currentDirectoryPath,
-        repositoryURLString: String,
-        branchOrTag: String,
-        verbose: Bool,
-        timeout: TimeInterval? = 15
-    ) throws -> Output {
-        try Shell.run(
-            "git clone --branch \(branchOrTag) --depth 1 \(repositoryURLString)",
-            workingDirectory: workingDirectory,
-            verbose: verbose,
-            timeout: timeout
-        )
-    }
+  @discardableResult
+  static func performShallowGitClone(
+    workingDirectory: String? = FileManager.default.currentDirectoryPath,
+    repositoryURLString: String,
+    branchOrTag: String,
+    verbose: Bool,
+    timeout: TimeInterval? = 15
+  ) async throws -> Output {
+    try await Shell.run(
+      "git clone --branch \(branchOrTag) --depth 1 \(repositoryURLString)",
+      workingDirectory: workingDirectory,
+      verbose: verbose,
+      timeout: timeout
+    )
+  }
 }
 
 // MARK: - Private
 
 private extension Shell {
-    static func runProcess(
-        workingDirectory: String?,
-        outputPipe: Pipe,
-        errorPipe: Pipe,
-        arguments: [String],
-        verbose: Bool,
-        timeout: TimeInterval?
-    ) throws -> Output {
-        let process = Process.make(
-            workingDirectory: workingDirectory,
-            outputPipe: outputPipe,
-            errorPipe: errorPipe,
-            arguments: arguments,
-            verbose: verbose
+  static func runProcess(
+    workingDirectory: String?,
+    outputPipe: Pipe,
+    errorPipe: Pipe,
+    arguments: [String],
+    verbose: Bool,
+    timeout: TimeInterval?
+  ) async throws -> Output {
+    let process = Process.make(
+      workingDirectory: workingDirectory,
+      outputPipe: outputPipe,
+      errorPipe: errorPipe,
+      arguments: arguments,
+      verbose: verbose
+    )
+
+    if verbose {
+      await Console.default.lineBreakAndWrite(
+        .init(
+          text: "Running Shell command",
+          color: .yellow
         )
-
-        if verbose {
-            Console.default.lineBreakAndWrite(
-                .init(
-                    text: "Running Shell command",
-                    color: .yellow
-                )
-            )
-        }
-
-        var outputData = Data()
-        var errorData = Data()
-
-        let dispatchGroup = DispatchGroup()
-
-        dispatchGroup.enter()
-        readData(
-            from: outputPipe,
-            isError: false,
-            verbose: verbose,
-            availableDataHandler: { availableData in
-                outputData.append(availableData)
-            },
-            hasFinishedHandler: {
-                dispatchGroup.leave()
-            }
-        )
-
-        dispatchGroup.enter()
-        readData(
-            from: errorPipe,
-            isError: true,
-            verbose: verbose,
-            availableDataHandler: { availableData in
-                errorData.append(availableData)
-            },
-            hasFinishedHandler: {
-                dispatchGroup.leave()
-            }
-        )
-
-        // TODO: Move to async await and re-implement timeout
-
-        try process.run()
-        process.waitUntilExit()
-
-        dispatchGroup.wait()
-
-        if verbose {
-            Console.default.lineBreakAndWrite(
-                .init(
-                    text: "Finished Shell command",
-                    color: .yellow
-                )
-            )
-        }
-
-        return .init(
-            succeeded: process.terminationStatus == 0,
-            data: outputData,
-            errorData: errorData
-        )
+      )
     }
 
-    static func readData(
-        from pipe: Pipe,
-        isError: Bool,
-        verbose: Bool,
-        availableDataHandler: ((Data) -> Void)?,
-        hasFinishedHandler: (() -> Void)?
-    ) {
-        pipe.fileHandleForReading.readabilityHandler = { fileHandle in
-            // readData(ofLength:) is used here to avoid unwanted performance side effects,
-            // as described in the findings from:
-            // https://stackoverflow.com/questions/49184623/nstask-race-condition-with-readabilityhandler-block
-            let data = fileHandle.readData(ofLength: .max)
+    var outputData = Data()
+    var errorData = Data()
 
-            if data.isEmpty == false {
-                String(data: data, encoding: .utf8).map {
-                    availableDataHandler?(data)
-                    guard verbose else { return }
+    try process.run()
 
-                    if isError {
-                        Console.default.lineBreakAndWrite(
-                            .init(
-                                text: $0,
-                                color: .red
-                            )
-                        )
-                    } else {
-                        Console.default.write(
-                            .init(
-                                text: $0,
-                                hasLineBreakAfter: false
-                            )
-                        )
-                    }
-                }
+    await withTaskGroup(of: Void.self) { taskGroup in
+      await readData(
+        from: outputPipe,
+        isError: false,
+        verbose: verbose,
+        availableDataHandler: { availableData in
+          outputData.append(availableData)
+        }
+      )
+      await readData(
+        from: errorPipe,
+        isError: true,
+        verbose: verbose,
+        availableDataHandler: { availableData in
+          errorData.append(availableData)
+        }
+      )
+    }
+
+    process.waitUntilExit()
+
+    if verbose {
+      await Console.default.lineBreakAndWrite(
+        .init(
+          text: "Finished Shell command",
+          color: .yellow
+        )
+      )
+    }
+
+    return .init(
+      succeeded: process.terminationStatus == 0,
+      data: outputData,
+      errorData: errorData
+    )
+  }
+
+  static func readData(
+    from pipe: Pipe,
+    isError: Bool,
+    verbose: Bool,
+    availableDataHandler: ((Data) -> Void)?
+  ) async {
+    await withCheckedContinuation { continuation in
+      pipe.fileHandleForReading.readabilityHandler = { fileHandle in
+        // readData(ofLength:) is used here to avoid unwanted performance side effects,
+        // as described in the findings from:
+        // https://stackoverflow.com/questions/49184623/nstask-race-condition-with-readabilityhandler-block
+        let data = fileHandle.readData(ofLength: .max)
+
+        if data.isEmpty == false {
+          String(data: data, encoding: .utf8).map {
+            availableDataHandler?(data)
+            guard verbose else { return }
+
+            let text = $0
+
+            if isError {
+              Task { @MainActor in
+                Console.default.lineBreakAndWrite(
+                  .init(
+                    text: text,
+                    color: .red
+                  )
+                )
+              }
             } else {
-                pipe.fileHandleForReading.readabilityHandler = nil
-                hasFinishedHandler?()
+              Task { @MainActor in
+                Console.default.write(
+                  .init(
+                    text: text,
+                    hasLineBreakAfter: false
+                  )
+                )
+              }
             }
+          }
+        } else {
+          pipe.fileHandleForReading.readabilityHandler = nil
+          continuation.resume()
         }
+      }
     }
+  }
 }
 
 extension Process {
-    static func make(
-        launchPath: String = "/usr/bin/env",
-        workingDirectory: String? = FileManager.default.currentDirectoryPath,
-        outputPipe: Pipe,
-        errorPipe: Pipe,
-        arguments: [String],
-        verbose: Bool
-    ) -> Process {
-        let process = Process()
-        process.launchPath = launchPath
-        process.arguments = arguments
-        process.standardError = errorPipe
-        process.standardOutput = outputPipe
-        process.qualityOfService = .userInteractive
-        if let workingDirectory = workingDirectory {
-            process.currentDirectoryPath = workingDirectory
-        }
-        return process
+  static func make(
+    launchPath: String = "/usr/bin/env",
+    workingDirectory: String? = FileManager.default.currentDirectoryPath,
+    outputPipe: Pipe,
+    errorPipe: Pipe,
+    arguments: [String],
+    verbose: Bool
+  ) -> Process {
+    let process = Process()
+    process.launchPath = launchPath
+    process.arguments = arguments
+    process.standardError = errorPipe
+    process.standardOutput = outputPipe
+    process.qualityOfService = .userInteractive
+    if let workingDirectory = workingDirectory {
+      process.currentDirectoryPath = workingDirectory
     }
+    return process
+  }
 }

--- a/Sources/Reports/Generators/ConsoleReportGenerator.swift
+++ b/Sources/Reports/Generators/ConsoleReportGenerator.swift
@@ -22,7 +22,7 @@ struct ConsoleReportGenerator {
 
   private let console: Console
 
-  init(console: Console) {
+  nonisolated init(console: Console) {
     self.console = console
   }
 

--- a/Sources/Reports/Generators/ConsoleReportGenerator.swift
+++ b/Sources/Reports/Generators/ConsoleReportGenerator.swift
@@ -1,6 +1,6 @@
 //
 //  ConsoleReportGenerator.swift
-//  
+//
 //  Acknowledgement: This piece of code is inspired by Raycast's script-commands repository:
 //  https://github.com/unnamedd/script-commands/blob/Toolkit/Improvements/Tools/Toolkit/Sources/ToolkitLibrary/Core/Report/Report.swift
 //
@@ -9,224 +9,225 @@
 
 import Core
 
+@MainActor
 struct ConsoleReportGenerator {
-    private enum Size {
-        static let cellMargin = 2
-        static let numberOfColumns = 2
+  private enum Size {
+    static let cellMargin = 2
+    static let numberOfColumns = 2
+  }
+
+  private static let mainTitle = "Swift Package Info"
+  private static let providerNameColumnTitle = "Provider"
+  private static let resultsColumnTitle = "Results"
+
+  private let console: Console
+
+  init(console: Console) {
+    self.console = console
+  }
+
+  func renderReport(
+    for swiftPackage: SwiftPackage,
+    providedInfos: [ProvidedInfo]
+  ) {
+    var firstColumnMaxContentSize = Self.providerNameColumnTitle.count
+    var secondColumnMaxContentSize = Self.resultsColumnTitle.count
+
+    providedInfos.forEach { providedInfo in
+      if case let providerNameSize = providedInfo.providerName.count,
+         providerNameSize > firstColumnMaxContentSize {
+        firstColumnMaxContentSize = providerNameSize
+      }
+
+      let totalMessageSize = providedInfo.messages
+        .map(\.text.count)
+        .reduce(0, +)
+      if totalMessageSize > secondColumnMaxContentSize {
+        secondColumnMaxContentSize = totalMessageSize
+      }
     }
 
-    private static let mainTitle = "Swift Package Info"
-    private static let providerNameColumnTitle = "Provider"
-    private static let resultsColumnTitle = "Results"
+    firstColumnMaxContentSize += Size.cellMargin
+    secondColumnMaxContentSize += Size.cellMargin
 
-    private let console: Console
+    var maxWidthWithoutLeftRightSeparators = firstColumnMaxContentSize
+    + secondColumnMaxContentSize
+    + ((Size.numberOfColumns - 1) * Divider.pipe.rawValue.count) // in between columns separators
 
-    init(console: Console = .default) {
-        self.console = console
+    let packageInfoRowWidth = swiftPackage.message.text.count + Size.cellMargin
+
+    if packageInfoRowWidth > maxWidthWithoutLeftRightSeparators {
+      let differenceInWidth = packageInfoRowWidth - maxWidthWithoutLeftRightSeparators
+      maxWidthWithoutLeftRightSeparators += differenceInWidth
+
+      let halfDifferenceInWidth = differenceInWidth / 2
+      firstColumnMaxContentSize += halfDifferenceInWidth
+      secondColumnMaxContentSize += halfDifferenceInWidth
+      + ((Size.numberOfColumns - 1) * Divider.pipe.rawValue.count) // in between columns separators
     }
 
-    func renderReport(
-        for swiftPackage: SwiftPackage,
-        providedInfos: [ProvidedInfo]
-    ) {
-        var firstColumnMaxContentSize = Self.providerNameColumnTitle.count
-        var secondColumnMaxContentSize = Self.resultsColumnTitle.count
+    console.lineBreak()
+    renderVerticalDivider(widthsInBetweenSeparators: [maxWidthWithoutLeftRightSeparators])
+    renderHorizontallyCenteredCell(
+      maxWidth: maxWidthWithoutLeftRightSeparators,
+      cell: .makeTitleCell(text: Self.mainTitle)
+    )
+    renderEmptyRow(size: maxWidthWithoutLeftRightSeparators)
+    renderHorizontallyCenteredCell(
+      maxWidth: maxWidthWithoutLeftRightSeparators,
+      cell: .init(messages: [swiftPackage.message])
+    )
 
-        providedInfos.forEach { providedInfo in
-            if case let providerNameSize = providedInfo.providerName.count,
-               providerNameSize > firstColumnMaxContentSize {
-                firstColumnMaxContentSize = providerNameSize
-            }
+    let columnsTotalSizes = [firstColumnMaxContentSize, secondColumnMaxContentSize]
+    renderVerticalDivider(widthsInBetweenSeparators: columnsTotalSizes)
 
-            let totalMessageSize = providedInfo.messages
-                .map(\.text.count)
-                .reduce(0, +)
-            if totalMessageSize > secondColumnMaxContentSize {
-                secondColumnMaxContentSize = totalMessageSize
-            }
-        }
+    let columnHeaderCells: [ReportCell] = [
+      .makeColumnHeaderCell(
+        title: Self.providerNameColumnTitle,
+        size: firstColumnMaxContentSize
+      ),
+      .makeColumnHeaderCell(
+        title: Self.resultsColumnTitle,
+        size: secondColumnMaxContentSize
+      )
+    ]
+    renderRow(for: columnHeaderCells)
 
-        firstColumnMaxContentSize += Size.cellMargin
-        secondColumnMaxContentSize += Size.cellMargin
+    renderVerticalDivider(widthsInBetweenSeparators: columnsTotalSizes)
 
-        var maxWidthWithoutLeftRightSeparators = firstColumnMaxContentSize
-            + secondColumnMaxContentSize
-            + ((Size.numberOfColumns - 1) * Divider.pipe.rawValue.count) // in between columns separators
-
-        let packageInfoRowWidth = swiftPackage.message.text.count + Size.cellMargin
-
-        if packageInfoRowWidth > maxWidthWithoutLeftRightSeparators {
-            let differenceInWidth = packageInfoRowWidth - maxWidthWithoutLeftRightSeparators
-            maxWidthWithoutLeftRightSeparators += differenceInWidth
-
-            let halfDifferenceInWidth = differenceInWidth / 2
-            firstColumnMaxContentSize += halfDifferenceInWidth
-            secondColumnMaxContentSize += halfDifferenceInWidth
-                + ((Size.numberOfColumns - 1) * Divider.pipe.rawValue.count) // in between columns separators
-        }
-
-        console.lineBreak()
-        renderVerticalDivider(widthsInBetweenSeparators: [maxWidthWithoutLeftRightSeparators])
-        renderHorizontallyCenteredCell(
-            maxWidth: maxWidthWithoutLeftRightSeparators,
-            cell: .makeTitleCell(text: Self.mainTitle)
+    providedInfos.forEach { providedInfo in
+      let rowCells: [ReportCell] = [
+        .makeProviderTitleCell(
+          named: providedInfo.providerName,
+          size: firstColumnMaxContentSize
+        ),
+        .makeForProvidedInfo(
+          providedInfo: providedInfo,
+          size: secondColumnMaxContentSize
         )
-        renderEmptyRow(size: maxWidthWithoutLeftRightSeparators)
-        renderHorizontallyCenteredCell(
-            maxWidth: maxWidthWithoutLeftRightSeparators,
-            cell: .init(messages: [swiftPackage.message])
-        )
+      ]
 
-        let columnsTotalSizes = [firstColumnMaxContentSize, secondColumnMaxContentSize]
-        renderVerticalDivider(widthsInBetweenSeparators: columnsTotalSizes)
-
-        let columnHeaderCells: [ReportCell] = [
-            .makeColumnHeaderCell(
-                title: Self.providerNameColumnTitle,
-                size: firstColumnMaxContentSize
-            ),
-            .makeColumnHeaderCell(
-                title: Self.resultsColumnTitle,
-                size: secondColumnMaxContentSize
-            )
-        ]
-        renderRow(for: columnHeaderCells)
-
-        renderVerticalDivider(widthsInBetweenSeparators: columnsTotalSizes)
-
-        providedInfos.forEach { providedInfo in
-            let rowCells: [ReportCell] = [
-                .makeProviderTitleCell(
-                    named: providedInfo.providerName,
-                    size: firstColumnMaxContentSize
-                ),
-                .makeForProvidedInfo(
-                    providedInfo: providedInfo,
-                    size: secondColumnMaxContentSize
-                )
-            ]
-
-            renderRow(for: rowCells)
-        }
-
-        renderVerticalDivider(widthsInBetweenSeparators: columnsTotalSizes)
-        console.write(
-            .init(
-                text: "> Total of ",
-                isBold: false,
-                hasLineBreakAfter: false
-            )
-        )
-        console.write(
-            .init(
-                text: "\(providedInfos.count)",
-                color: .cyan,
-                isBold: true,
-                hasLineBreakAfter: false
-            )
-        )
-        console.write(
-            .init(
-                text: " \(providedInfos.count > 1 ? "providers" : "provider") used.",
-                isBold: false, hasLineBreakAfter: true
-            )
-        )
-        console.lineBreak()
+      renderRow(for: rowCells)
     }
+
+    renderVerticalDivider(widthsInBetweenSeparators: columnsTotalSizes)
+    console.write(
+      .init(
+        text: "> Total of ",
+        isBold: false,
+        hasLineBreakAfter: false
+      )
+    )
+    console.write(
+      .init(
+        text: "\(providedInfos.count)",
+        color: .cyan,
+        isBold: true,
+        hasLineBreakAfter: false
+      )
+    )
+    console.write(
+      .init(
+        text: " \(providedInfos.count > 1 ? "providers" : "provider") used.",
+        isBold: false, hasLineBreakAfter: true
+      )
+    )
+    console.lineBreak()
+  }
 }
 
 private extension ConsoleReportGenerator {
-    func renderHorizontallyCenteredCell(maxWidth: Int, cell: ReportCell) {
-        let halfMaxWidth = maxWidth / 2
-        let halfCellWidth = cell.size / 2
+  func renderHorizontallyCenteredCell(maxWidth: Int, cell: ReportCell) {
+    let halfMaxWidth = maxWidth / 2
+    let halfCellWidth = cell.size / 2
 
-        let leadingOffset = halfMaxWidth - halfCellWidth
-        let titleLeadingMargin = String(
+    let leadingOffset = halfMaxWidth - halfCellWidth
+    let titleLeadingMargin = String(
+      repeating: Divider.space.rawValue,
+      count: leadingOffset
+    )
+
+    let trailingOffset = maxWidth - (leadingOffset + cell.size)
+    let titleTrailingMargin = String(
+      repeating: Divider.space.rawValue,
+      count: trailingOffset
+    )
+
+    console.write(Divider.pipe.message)
+    console.write(
+      .init(
+        text: titleLeadingMargin,
+        hasLineBreakAfter: false
+      )
+    )
+    cell.messages.forEach(console.write)
+    console.write(
+      .init(
+        text: titleTrailingMargin,
+        hasLineBreakAfter: false
+      )
+    )
+    console.write(.init(text: Divider.pipe.rawValue))
+  }
+
+  func renderRow(for cells: [ReportCell]) {
+    console.write(Divider.pipe.message)
+
+    cells.forEach { cell in
+      var sizeToFillWithSpace = cell.size - cell.textSize
+      console.write(Divider.space.message)
+      sizeToFillWithSpace -= 1
+
+      cell.messages.forEach(console.write)
+      console.write(
+        .init(
+          text: String(
             repeating: Divider.space.rawValue,
-            count: leadingOffset
+            count: sizeToFillWithSpace
+          ),
+          hasLineBreakAfter: false
         )
-
-        let trailingOffset = maxWidth - (leadingOffset + cell.size)
-        let titleTrailingMargin = String(
-            repeating: Divider.space.rawValue,
-            count: trailingOffset
-        )
-
-        console.write(Divider.pipe.message)
-        console.write(
-            .init(
-                text: titleLeadingMargin,
-                hasLineBreakAfter: false
-            )
-        )
-        cell.messages.forEach(console.write)
-        console.write(
-            .init(
-                text: titleTrailingMargin,
-                hasLineBreakAfter: false
-            )
-        )
-        console.write(.init(text: Divider.pipe.rawValue))
+      )
+      console.write(Divider.pipe.message)
     }
 
-    func renderRow(for cells: [ReportCell]) {
-        console.write(Divider.pipe.message)
+    console.lineBreak()
+  }
 
-        cells.forEach { cell in
-            var sizeToFillWithSpace = cell.size - cell.textSize
-            console.write(Divider.space.message)
-            sizeToFillWithSpace -= 1
+  func renderEmptyRow(size: Int) {
+    console.write(Divider.pipe.message)
+    console.write(
+      .init(
+        text: String(repeating: Divider.space.rawValue, count: size),
+        hasLineBreakAfter: false
+      )
+    )
+    console.write(Divider.pipe.message)
+    console.lineBreak()
+  }
 
-            cell.messages.forEach(console.write)
-            console.write(
-                .init(
-                    text: String(
-                        repeating: Divider.space.rawValue,
-                        count: sizeToFillWithSpace
-                    ),
-                    hasLineBreakAfter: false
-                )
-            )
-            console.write(Divider.pipe.message)
-        }
+  func renderVerticalDivider(widthsInBetweenSeparators: [Int]) {
+    var divider = Divider.plus.rawValue
 
-        console.lineBreak()
+    widthsInBetweenSeparators.forEach { width in
+      divider += String(repeating: Divider.minus.rawValue, count: width)
+      divider += Divider.plus.rawValue
     }
 
-    func renderEmptyRow(size: Int) {
-        console.write(Divider.pipe.message)
-        console.write(
-            .init(
-                text: String(repeating: Divider.space.rawValue, count: size),
-                hasLineBreakAfter: false
-            )
-        )
-        console.write(Divider.pipe.message)
-        console.lineBreak()
-    }
-
-    func renderVerticalDivider(widthsInBetweenSeparators: [Int]) {
-        var divider = Divider.plus.rawValue
-
-        widthsInBetweenSeparators.forEach { width in
-            divider += String(repeating: Divider.minus.rawValue, count: width)
-            divider += Divider.plus.rawValue
-        }
-
-        console.write(.init(text: divider))
-    }
+    console.write(.init(text: divider))
+  }
 }
 
 private enum Divider: String, CustomConsoleMessageConvertible {
-    case minus = "-"
-    case pipe = "|"
-    case plus = "+"
-    case space = " "
+  case minus = "-"
+  case pipe = "|"
+  case plus = "+"
+  case space = " "
 
-    var message: ConsoleMessage {
-        .init(
-            text: rawValue,
-            hasLineBreakAfter: false
-        )
-    }
+  var message: ConsoleMessage {
+    .init(
+      text: rawValue,
+      hasLineBreakAfter: false
+    )
+  }
 }

--- a/Sources/Reports/Generators/JSONDumpReportGenerator.swift
+++ b/Sources/Reports/Generators/JSONDumpReportGenerator.swift
@@ -21,7 +21,7 @@
 import Core
 import Foundation
 
-struct JSONDumpReportGenerator {
+struct JSONDumpReportGenerator: Sendable {
   private let console: Console
   private let encoder: JSONEncoder
 
@@ -33,6 +33,7 @@ struct JSONDumpReportGenerator {
     self.encoder = encoder
   }
 
+  @Sendable
   func renderDump(
     for swiftPackage: SwiftPackage,
     providedInfos: [ProvidedInfo]

--- a/Sources/Reports/Generators/JSONDumpReportGenerator.swift
+++ b/Sources/Reports/Generators/JSONDumpReportGenerator.swift
@@ -22,48 +22,50 @@ import Core
 import Foundation
 
 struct JSONDumpReportGenerator {
-    private let console: Console
-    private let encoder: JSONEncoder
+  private let console: Console
+  private let encoder: JSONEncoder
 
-    init(
-        console: Console = .default,
-        encoder: JSONEncoder = .sortedAndPrettyPrinted
-    ) {
-        self.console = console
-        self.encoder = encoder
+  init(
+    console: Console,
+    encoder: JSONEncoder = .sortedAndPrettyPrinted
+  ) {
+    self.console = console
+    self.encoder = encoder
+  }
+
+  func renderDump(
+    for swiftPackage: SwiftPackage,
+    providedInfos: [ProvidedInfo]
+  ) throws {
+    let reportData = ReportData(
+      providedInfos: providedInfos
+    )
+
+    let data = try encoder.encode(reportData)
+    let stringData = String(data: data, encoding: .utf8) ?? ""
+
+    Task { @MainActor in
+      console.write(
+        .init(text: stringData)
+      )
     }
-
-    func renderDump(
-        for swiftPackage: SwiftPackage,
-        providedInfos: [ProvidedInfo]
-    ) throws {
-        let reportData = ReportData(
-            providedInfos: providedInfos
-        )
-
-        let data = try encoder.encode(reportData)
-        let stringData = String(data: data, encoding: .utf8) ?? ""
-
-        console.write(
-            .init(text: stringData)
-        )
-    }
+  }
 }
 
 struct ReportData: Encodable {
-    let providedInfos: [ProvidedInfo]
+  let providedInfos: [ProvidedInfo]
 
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: ProviderKind.self)
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: ProviderKind.self)
 
-        if let binarySizeInfo = providedInfos.first(where: \.providerKind == .binarySize) {
-            try container.encode(binarySizeInfo, forKey: .binarySize)
-        }
-        if let dependenciesInfo = providedInfos.first(where: \.providerKind == .dependencies) {
-            try container.encode(dependenciesInfo, forKey: .dependencies)
-        }
-        if let platformsInfo = providedInfos.first(where: \.providerKind == .platforms) {
-            try container.encode(platformsInfo, forKey: .platforms)
-        }
+    if let binarySizeInfo = providedInfos.first(where: \.providerKind == .binarySize) {
+      try container.encode(binarySizeInfo, forKey: .binarySize)
     }
+    if let dependenciesInfo = providedInfos.first(where: \.providerKind == .dependencies) {
+      try container.encode(dependenciesInfo, forKey: .dependencies)
+    }
+    if let platformsInfo = providedInfos.first(where: \.providerKind == .platforms) {
+      try container.encode(platformsInfo, forKey: .platforms)
+    }
+  }
 }

--- a/Sources/Reports/Generators/ReportGenerating.swift
+++ b/Sources/Reports/Generators/ReportGenerating.swift
@@ -21,6 +21,6 @@
 import Core
 
 typealias ReportGenerating = (
-    _ swiftPackage: SwiftPackage,
-    _ providedInfos: [ProvidedInfo]
-) throws -> Void
+  _ swiftPackage: SwiftPackage,
+  _ providedInfos: [ProvidedInfo]
+) async throws -> Void

--- a/Sources/Reports/Report.swift
+++ b/Sources/Reports/Report.swift
@@ -47,7 +47,7 @@ public final class Report: Reporting {
     for providedInfos: [ProvidedInfo],
     format: ReportFormat
   ) async throws {
-    let reportGenerator = await format.makeReportGenerator(console: console)
+    let reportGenerator = format.makeReportGenerator(console: console)
     try await reportGenerator(
       swiftPackage,
       providedInfos

--- a/Sources/Reports/Report.swift
+++ b/Sources/Reports/Report.swift
@@ -27,7 +27,7 @@ public final class Report: Reporting {
 
   public init(
     swiftPackage: SwiftPackage,
-    console: Console = .default
+    console: Console
   ) {
     self.swiftPackage = swiftPackage
     self.console = console
@@ -36,8 +36,8 @@ public final class Report: Reporting {
   public func generate(
     for providedInfo: ProvidedInfo,
     format: ReportFormat
-  ) throws {
-    try generate(
+  ) async throws {
+    try await generate(
       for: [providedInfo],
       format: format
     )
@@ -46,9 +46,9 @@ public final class Report: Reporting {
   public func generate(
     for providedInfos: [ProvidedInfo],
     format: ReportFormat
-  ) throws {
-    let reportGenerator = format.makeReportGenerator()
-    try reportGenerator(
+  ) async throws {
+    let reportGenerator = await format.makeReportGenerator(console: console)
+    try await reportGenerator(
       swiftPackage,
       providedInfos
     )
@@ -57,7 +57,7 @@ public final class Report: Reporting {
 
 // MARK: - SwiftPackage: CustomConsoleMessageConvertible
 
-extension SwiftPackage: CustomConsoleMessageConvertible {
+extension SwiftPackage: @retroactive CustomConsoleMessageConvertible {
   public var message: ConsoleMessage {
     .init(
       text: "\(product), \(versionOrRevision)",

--- a/Sources/Reports/ReportFormat.swift
+++ b/Sources/Reports/ReportFormat.swift
@@ -21,17 +21,18 @@
 import Core
 
 public enum ReportFormat: String, CaseIterable {
-    case consoleMessage
-    case jsonDump
+  case consoleMessage
+  case jsonDump
 }
 
 extension ReportFormat {
-    func makeReportGenerator(console: Console = .default) -> ReportGenerating {
-        switch self {
-        case .consoleMessage:
-            return ConsoleReportGenerator(console: console).renderReport
-        case .jsonDump:
-            return JSONDumpReportGenerator(console: console).renderDump
-        }
+  @MainActor
+  func makeReportGenerator(console: Console) -> ReportGenerating {
+    switch self {
+    case .consoleMessage:
+      ConsoleReportGenerator(console: console).renderReport
+    case .jsonDump:
+      JSONDumpReportGenerator(console: console).renderDump
     }
+  }
 }

--- a/Sources/Reports/ReportFormat.swift
+++ b/Sources/Reports/ReportFormat.swift
@@ -20,13 +20,12 @@
 
 import Core
 
-public enum ReportFormat: String, CaseIterable {
+public enum ReportFormat: String, CaseIterable, Sendable {
   case consoleMessage
   case jsonDump
 }
 
 extension ReportFormat {
-  @MainActor
   func makeReportGenerator(console: Console) -> ReportGenerating {
     switch self {
     case .consoleMessage:

--- a/Sources/Reports/Reporting.swift
+++ b/Sources/Reports/Reporting.swift
@@ -21,8 +21,8 @@
 import Core
 
 protocol Reporting {
-    var swiftPackage: SwiftPackage { get }
+  var swiftPackage: SwiftPackage { get }
 
-    func generate(for _: ProvidedInfo, format: ReportFormat) throws
-    func generate(for _: [ProvidedInfo], format: ReportFormat) throws
+  func generate(for _: ProvidedInfo, format: ReportFormat) async throws
+  func generate(for _: [ProvidedInfo], format: ReportFormat) async throws
 }

--- a/Sources/Run/Subcommands/BinarySize.swift
+++ b/Sources/Run/Subcommands/BinarySize.swift
@@ -47,38 +47,50 @@ extension SwiftPackageInfo {
 
     public init() {}
 
-    public func run() async throws {
+    public func run() async throws {      
       try runArgumentsValidation(arguments: allArguments)
       var swiftPackage = makeSwiftPackage(from: allArguments)
-      swiftPackage.messages.forEach(Console.default.lineBreakAndWrite)
+
+      Task { @MainActor in
+        swiftPackage.messages.forEach(Console.default.lineBreakAndWrite)
+      }
 
       let package = try await validate(
         swiftPackage: &swiftPackage,
         verbose: allArguments.verbose
       )
 
-      let report = Report(swiftPackage: swiftPackage)
-
       let packageWrapper = PackageWrapper(from: package)
 
-      try BinarySizeProvider.fetchInformation(
-        for: swiftPackage,
-        package: packageWrapper, 
-        xcconfig: allArguments.xcconfig,
-        verbose: allArguments.verbose
-      )
-      .onSuccess {
-        try report.generate(
-          for: $0,
+      let providedInfo: ProvidedInfo?
+      do {
+        providedInfo = try await BinarySizeProvider.fetchInformation(
+          for: swiftPackage,
+          package: packageWrapper,
+          xcconfig: allArguments.xcconfig,
+          verbose: allArguments.verbose
+        )
+      } catch {
+        providedInfo = nil
+        if let providerError = error as? InfoProviderError {
+          Task { @MainActor in
+            Console.default.write(providerError.message)
+          }
+        }
+      }
+
+      if let providedInfo {
+        let report = await Report(swiftPackage: swiftPackage, console: .default)
+        try await report.generate(
+          for: providedInfo,
           format: allArguments.report
         )
       }
-      .onFailure { Console.default.write($0.message) }
     }
   }
 }
 
-extension SwiftPackage: CustomConsoleMessagesConvertible {
+extension SwiftPackage: @retroactive CustomConsoleMessagesConvertible {
   public var messages: [ConsoleMessage] {
     [
       .init(

--- a/Sources/Run/Subcommands/BinarySize.swift
+++ b/Sources/Run/Subcommands/BinarySize.swift
@@ -32,7 +32,7 @@ extension SwiftPackageInfo {
         Such a strategy has proven to be very consistent with the size added to iOS apps downloaded and installed via TestFlight.
         """
 
-    public static var configuration = CommandConfiguration(
+    public static let configuration = CommandConfiguration(
       abstract: "Estimated binary size of a Swift Package product.",
       discussion: """
             Measures the estimated binary size impact of a Swift Package product,

--- a/Sources/Run/Subcommands/Dependencies.swift
+++ b/Sources/Run/Subcommands/Dependencies.swift
@@ -41,30 +41,39 @@ extension SwiftPackageInfo {
     public func run() async throws {
       try runArgumentsValidation(arguments: allArguments)
       var swiftPackage = makeSwiftPackage(from: allArguments)
-      swiftPackage.messages.forEach(Console.default.lineBreakAndWrite)
+      Task { @MainActor in
+        swiftPackage.messages.forEach(Console.default.lineBreakAndWrite)
+      }
 
       let package = try await validate(
         swiftPackage: &swiftPackage,
         verbose: allArguments.verbose
       )
 
-      let report = Report(swiftPackage: swiftPackage)
-
       let packageWrapper = PackageWrapper(from: package)
 
-      try DependenciesProvider.fetchInformation(
-        for: swiftPackage,
-        package: packageWrapper, 
-        xcconfig: allArguments.xcconfig,
-        verbose: allArguments.verbose
-      )
-      .onSuccess {
-        try report.generate(
-          for: $0,
-          format: allArguments.report
+      do {
+        let providedInfo = try await DependenciesProvider.fetchInformation(
+          for: swiftPackage,
+          package: packageWrapper,
+          xcconfig: allArguments.xcconfig,
+          verbose: allArguments.verbose
         )
+
+        Task { @MainActor in
+          let report = Report(swiftPackage: swiftPackage, console: .default)
+          try await report.generate(
+            for: providedInfo,
+            format: allArguments.report
+          )
+        }
+      } catch {
+        if let providerError = error as? InfoProviderError {
+          Task { @MainActor in
+            Console.default.write(providerError.message)
+          }
+        }
       }
-      .onFailure { Console.default.write($0.message) }
     }
   }
 }

--- a/Sources/Run/Subcommands/FullAnalyzes.swift
+++ b/Sources/Run/Subcommands/FullAnalyzes.swift
@@ -54,8 +54,6 @@ extension SwiftPackageInfo {
         verbose: allArguments.verbose
       )
 
-      let report = await Report(swiftPackage: swiftPackage, console: .default)
-
       let packageWrapper = PackageWrapper(from: package)
 
       // All copies to silence Swift 6 concurrency `sending` warnings
@@ -84,6 +82,7 @@ extension SwiftPackageInfo {
         return providedInfos
       }
 
+      let report = await Report(swiftPackage: swiftPackage, console: .default)
       try await report.generate(
         for: providedInfos,
         format: allArguments.report

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -33,10 +33,10 @@ public struct SwiftPackageInfo: AsyncParsableCommand {
   public static var configuration = CommandConfiguration(
     abstract: "A tool for analyzing Swift Packages",
     discussion: """
-        Provides valuable information about a given Swift Package,
-        that can be used in your favor when deciding whether to
-        adopt or not a Swift Package as a dependency on your app.
-        """,
+    Provides valuable information about a given Swift Package,
+    that can be used in your favor when deciding whether to
+    adopt or not a Swift Package as a dependency on your app.
+    """,
     version: "1.4.1",
     subcommands: [
       BinarySize.self,
@@ -69,9 +69,9 @@ struct AllArguments: ParsableArguments {
       .customLong("local-path"),
     ],
     help: """
-        Either a valid git repository URL or a relative local directory path that contains a `Package.swift`
-        - Note: For local packages full paths are discouraged and unsupported.
-        """
+    Either a valid git repository URL or a relative local directory path that contains a `Package.swift`
+    - Note: For local packages full paths are discouraged and unsupported.
+    """
   )
   var url: URL
 
@@ -111,16 +111,15 @@ struct AllArguments: ParsableArguments {
       .customLong("output-format")
     ],
     help: """
-        Define the report output format/strategy. Supported values are:
-        - \(
-            ReportFormat.allCases.map(\.rawValue)
-                .joined(separator: "\n- ")
-        )
-
-        """
+    Define the report output format/strategy. Supported values are:
+    - \(
+        ReportFormat.allCases.map(\.rawValue)
+            .joined(separator: "\n- ")
+    )
+    """
   )
   var report: ReportFormat = .consoleMessage
-  
+
   @Option(
     name: [
       .customLong("xcconfig"),
@@ -150,32 +149,32 @@ extension ParsableCommand {
 
     guard arguments.url.absoluteString.first != "/" else {
       throw CleanExit.message(
-                """
-                Error: Invalid argument '--url <url>'
-                Usage: Absolute paths aren't supported! Please pass a relative path to your local package.
-                """
+        """
+        Error: Invalid argument '--url <url>'
+        Usage: Absolute paths aren't supported! Please pass a relative path to your local package.
+        """
       )
     }
 
     guard isValidRemoteURL || isValidLocalDirectory == true else {
       throw CleanExit.message(
-                """
-                Error: Invalid argument '--url <url>'
-                Usage: The URL must be either:
-                - A valid git repository URL that contains a `Package.swift`, e.g `https://github.com/Alamofire/Alamofire`; or
-                - A relative local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
-                """
+        """
+        Error: Invalid argument '--url <url>'
+        Usage: The URL must be either:
+        - A valid git repository URL that contains a `Package.swift`, e.g `https://github.com/Alamofire/Alamofire`; or
+        - A relative local directory path that has a `Package.swift`, e.g. `../other-dir/my-project`
+        """
       )
     }
-      
-      if isValidLocalCustomFile == false {
-          throw CleanExit.message(
-                    """
-                    Error: Invalid argument '--xcconfig <url>'
-                    Usage: The URL must be a relative local file path that has point to a `.xcconfig` file, e.g. `../other-dir/CustomConfiguration.xcconfig`
-                    """
-          )
-      }
+
+    if isValidLocalCustomFile == false {
+      throw CleanExit.message(
+        """
+        Error: Invalid argument '--xcconfig <url>'
+        Usage: The URL must be a relative local file path that has point to a `.xcconfig` file, e.g. `../other-dir/CustomConfiguration.xcconfig`
+        """
+      )
+    }
   }
 
   func makeSwiftPackage(from arguments: AllArguments) -> SwiftPackage {
@@ -212,20 +211,20 @@ extension ParsableCommand {
 
       switch swiftPackage.resolution {
       case let .revision(revision):
-        Console.default.lineBreakAndWrite("Resolved revision: \(revision)")
-        case .version:
-          switch tagState {
-          case .undefined, .invalid:
-            Console.default.lineBreakAndWrite("Package version was \(tagState.description)")
+        await Console.default.lineBreakAndWrite("Resolved revision: \(revision)")
+      case .version:
+        switch tagState {
+        case .undefined, .invalid:
+          await Console.default.lineBreakAndWrite("Package version was \(tagState.description)")
 
-            if let latestTag {
-              Console.default.lineBreakAndWrite("Defaulting to latest found semver tag: \(latestTag)")
-              swiftPackage.resolution = .version(latestTag)
-            }
-          case .valid:
-            break
+          if let latestTag {
+            await Console.default.lineBreakAndWrite("Defaulting to latest found semver tag: \(latestTag)")
+            swiftPackage.resolution = .version(latestTag)
           }
+        case .valid:
+          break
         }
+      }
     case .local:
       break
     }
@@ -237,8 +236,8 @@ extension ParsableCommand {
     }
 
     if packageResponse.isProductValid == false {
-      Console.default.lineBreakAndWrite("Invalid product: \(swiftPackage.product)")
-      Console.default.lineBreakAndWrite("Using first found product instead: \(firstProduct)")
+      await Console.default.lineBreakAndWrite("Invalid product: \(swiftPackage.product)")
+      await Console.default.lineBreakAndWrite("Using first found product instead: \(firstProduct)")
 
       swiftPackage.product = firstProduct
     }

--- a/Sources/Run/SwiftPackageInfo.swift
+++ b/Sources/Run/SwiftPackageInfo.swift
@@ -30,7 +30,7 @@ import PackageModel
 
 @main
 public struct SwiftPackageInfo: AsyncParsableCommand {
-  public static var configuration = CommandConfiguration(
+  public static let configuration = CommandConfiguration(
     abstract: "A tool for analyzing Swift Packages",
     discussion: """
     Provides valuable information about a given Swift Package,
@@ -47,7 +47,7 @@ public struct SwiftPackageInfo: AsyncParsableCommand {
     defaultSubcommand: FullAnalyzes.self
   )
 
-  static var subcommandsProviders: [InfoProvider] = [
+  static let subcommandsProviders: [InfoProvider] = [
     BinarySizeProvider.fetchInformation(for:package:xcconfig:verbose:),
     PlatformsProvider.fetchInformation(for:package:xcconfig:verbose:),
     DependenciesProvider.fetchInformation(for:package:xcconfig:verbose:)

--- a/Sources/Run/TSCUtility+Run.swift
+++ b/Sources/Run/TSCUtility+Run.swift
@@ -21,7 +21,7 @@
 import ArgumentParser
 import TSCUtility
 
-extension TSCUtility.Version: ExpressibleByArgument {
+extension TSCUtility.Version: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(argument)
     }

--- a/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderTests.swift
+++ b/Tests/AppTests/Providers/BinarySizeProvider/BinarySizeProviderTests.swift
@@ -25,35 +25,35 @@ import CoreTestSupport
 @testable import Core
 
 final class BinarySizeProviderTests: XCTestCase {
-  func testFetchInformation() throws {
+  func testFetchInformation() async throws {
     var defaultSizeMeasurerCallsCount = 0
     var lastVerbose: Bool?
-
+    
     var sizeMeasurerCallsCount = 0
     var lastSwiftPackage: SwiftPackage?
     var lastIsDynamic: Bool?
-
+    
     defaultSizeMeasurer = { xcconfig, verbose in
       lastVerbose = verbose
       defaultSizeMeasurerCallsCount += 1
-
+      
       return { swiftPackage, isDynamic in
         lastSwiftPackage = swiftPackage
         lastIsDynamic = isDynamic
         sizeMeasurerCallsCount += 1
-
+        
         return .init(
           amount: 908,
           formatted: "908 kb"
         )
       }
     }
-
+    
     let productName = "Product"
     let swiftPackage = Fixture.makeSwiftPackage(
       product: productName
     )
-    let result = BinarySizeProvider.fetchInformation(
+    let providedInfo = try await BinarySizeProvider.fetchInformation(
       for: swiftPackage,
       package: Fixture.makePackageWrapper(
         products: [
@@ -73,8 +73,7 @@ final class BinarySizeProviderTests: XCTestCase {
       xcconfig: nil,
       verbose: true
     )
-
-    let providedInfo = try result.get()
+    
     XCTAssertEqual(
       providedInfo.providerName,
       "Binary Size"
@@ -83,7 +82,7 @@ final class BinarySizeProviderTests: XCTestCase {
       providedInfo.providerKind,
       .binarySize
     )
-
+    
     XCTAssertEqual(
       defaultSizeMeasurerCallsCount,
       1
@@ -104,7 +103,7 @@ final class BinarySizeProviderTests: XCTestCase {
       lastIsDynamic,
       true
     )
-
+    
     XCTAssertEqual(
       providedInfo.messages,
       [
@@ -122,13 +121,13 @@ final class BinarySizeProviderTests: XCTestCase {
         )
       ]
     )
-
+    
     let encodedProvidedInfo = try JSONEncoder.sortedAndPrettyPrinted.encode(providedInfo)
     let encodedProvidedInfoString = String(
       data: encodedProvidedInfo,
       encoding: .utf8
     )
-
+    
     XCTAssertEqual(
       encodedProvidedInfoString,
       #"""

--- a/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
+++ b/Tests/AppTests/Providers/DependenciesProvider/DependenciesProviderTests.swift
@@ -25,7 +25,7 @@ import CoreTestSupport
 @testable import Core
 
 final class DependenciesProviderTests: XCTestCase {
-  func testWithTransitiveDependencies() throws {
+  func testWithTransitiveDependencies() async throws {
     let productName = "Some"
 
     let target3 = PackageWrapper.Target(
@@ -80,7 +80,7 @@ final class DependenciesProviderTests: XCTestCase {
       ]
     )
 
-    let result = DependenciesProvider.fetchInformation(
+    let providedInfo = try await DependenciesProvider.fetchInformation(
       for: Fixture.makeSwiftPackage(
         product: productName
       ),
@@ -105,7 +105,6 @@ final class DependenciesProviderTests: XCTestCase {
       verbose: true
     )
 
-    let providedInfo = try result.get()
     XCTAssertEqual(
       providedInfo.providerName,
       "Dependencies"
@@ -164,7 +163,7 @@ final class DependenciesProviderTests: XCTestCase {
     )
   }
 
-  func testWithMoreThan3ExternalDependencies() throws {
+  func testWithMoreThan3ExternalDependencies() async throws {
     let productName = "Some"
 
     let target = PackageWrapper.Target(
@@ -205,7 +204,7 @@ final class DependenciesProviderTests: XCTestCase {
       ]
     )
 
-    let result = DependenciesProvider.fetchInformation(
+    let providedInfo = try await DependenciesProvider.fetchInformation(
       for: Fixture.makeSwiftPackage(
         product: productName
       ),
@@ -228,7 +227,6 @@ final class DependenciesProviderTests: XCTestCase {
       verbose: true
     )
 
-    let providedInfo = try result.get()
     XCTAssertEqual(
       providedInfo.providerName,
       "Dependencies"

--- a/Tests/AppTests/Providers/PlatformsProvider/PlatformsProviderTests.swift
+++ b/Tests/AppTests/Providers/PlatformsProvider/PlatformsProviderTests.swift
@@ -25,8 +25,8 @@ import CoreTestSupport
 @testable import Core
 
 final class PlatformsProviderTests: XCTestCase {
-  func testFetchInformation() throws {
-    let result = PlatformsProvider.fetchInformation(
+  func testFetchInformation() async throws {
+    let providedInfo = try await PlatformsProvider.fetchInformation(
       for: Fixture.makeSwiftPackage(),
       package: Fixture.makePackageWrapper(
         platforms: [
@@ -49,7 +49,6 @@ final class PlatformsProviderTests: XCTestCase {
       verbose: true
     )
 
-    let providedInfo = try result.get()
     XCTAssertEqual(
       providedInfo.providerName,
       "Platforms"

--- a/Tests/CoreTests/URLExtensionTests.swift
+++ b/Tests/CoreTests/URLExtensionTests.swift
@@ -22,246 +22,249 @@ import XCTest
 @testable import Core
 
 final class URLExtensionTests: XCTestCase {
-    enum TestFile: String, CaseIterable {
-        case file
-        case file1
+  enum TestFile: String, CaseIterable {
+    case file
+    case file1
+  }
+
+  private var fileManager: FileManager! = .default
+  private lazy var temporaryTestDirectoryPath: String = fileManager.currentDirectoryPath.appending("/TemporaryTest")
+  private lazy var temporaryTestDirectoryURL: URL = URL(fileURLWithPath: temporaryTestDirectoryPath)
+  private lazy var defaultTestFileURL: URL = makeTestFileURL()
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+
+    try fileManager.createDirectory(atPath: temporaryTestDirectoryPath)
+  }
+
+  override func tearDownWithError() throws {
+    try fileManager.removeItem(atPath: temporaryTestDirectoryPath)
+    fileManager = nil
+
+    try super.tearDownWithError()
+  }
+
+  @MainActor
+  func testByteCountFormatter() {
+    let sut = URL.fileByteCountFormatter
+    XCTAssertEqual(sut.countStyle, .file)
+  }
+
+  func testTotalFileAllocatedSize() throws {
+    try createTestFile(atPath: defaultTestFileURL.path)
+
+    XCTAssertEqual(try defaultTestFileURL.totalFileAllocatedSize(), 4096)
+  }
+
+  func testIsDirectoryForFile() throws {
+    try createTestFile(atPath: defaultTestFileURL.path)
+
+    XCTAssertFalse(try defaultTestFileURL.isDirectory())
+  }
+
+  func testIsDirectoryForDirectory() throws {
+    XCTAssertTrue(try temporaryTestDirectoryURL.isDirectory())
+  }
+
+  func testDirectoryTotalAllocatedSizeIncludingSubfolders() throws {
+    // create a file
+    try createTestFile(atPath: defaultTestFileURL.path)
+
+    // then
+    XCTAssertEqual(
+      try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: true),
+      4096
+    )
+
+    // create a subfolder
+    let subDirectoryURL = URL(
+      fileURLWithPath: temporaryTestDirectoryPath
+        .appending("/Subdirectory")
+    )
+    try fileManager.createDirectory(atPath: subDirectoryURL.path)
+
+    // Add a file to the subfolder
+    try createTestFile(
+      atPath: makeTestFileURL(directoryURL: subDirectoryURL, componentName: TestFile.file1.rawValue).path,
+      content: String(repeating: "1", count: 5_000).data(using: .utf8)!
+    )
+
+    // create another file to the main folder
+    try createTestFile(
+      atPath: makeTestFileURL(componentName: TestFile.file1.rawValue).path,
+      content: String(repeating: "1", count: 5_000).data(using: .utf8)!
+    )
+
+    // then
+    XCTAssertEqual(
+      try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: true),
+      20480
+    )
+  }
+
+  func testDirectoryTotalAllocatedSizeWithoutIncludingSubfolders() throws {
+    // create a file
+    try createTestFile(atPath: defaultTestFileURL.path)
+
+    // then
+    XCTAssertEqual(
+      try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: false),
+      4096
+    )
+
+    // create a subfolder
+    let subDirectoryURL = URL(
+      fileURLWithPath: temporaryTestDirectoryPath
+        .appending("/Subdirectory")
+    )
+    try fileManager.createDirectory(atPath: subDirectoryURL.path)
+
+    // Add a file to the subfolder
+    try createTestFile(
+      atPath: makeTestFileURL(directoryURL: subDirectoryURL, componentName: TestFile.file1.rawValue).path,
+      content: String(repeating: "1", count: 5_000).data(using: .utf8)!
+    )
+
+    // create another file to the main folder
+    try createTestFile(
+      atPath: makeTestFileURL(componentName: TestFile.file1.rawValue).path,
+      content: String(repeating: "1", count: 5_000).data(using: .utf8)!
+    )
+
+    // then
+    XCTAssertEqual(
+      try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: false),
+      12288
+    )
+  }
+
+  @MainActor
+  func testSizeOnDiskForFile() throws {
+    try createTestFile(atPath: defaultTestFileURL.path)
+
+    XCTAssertEqual(
+      try defaultTestFileURL.sizeOnDisk(),
+      .init(amount: 4096, formatted: "4 KB")
+    )
+  }
+
+  @MainActor
+  func testSizeOnDiskForDirectory() throws {
+    // Check initial directory size
+    XCTAssertEqual(
+      try temporaryTestDirectoryURL.sizeOnDisk(),
+      .init(amount: 0, formatted: "Zero KB")
+    )
+
+    // Create a new file in temporaryDirectory
+    try createTestFile(
+      atPath: defaultTestFileURL.path,
+      content: String(repeating: "1", count: 500_000).data(using: .utf8)!
+    )
+
+    // Then
+    XCTAssertEqual(
+      try temporaryTestDirectoryURL.sizeOnDisk(),
+      .init(amount: 503808, formatted: "504 KB")
+    )
+  }
+
+  // MARK: Tests - isValidLocalDirectory
+
+  func testIsValidLocalDirectoryWhenDoesNotContainPackageDotSwift() throws {
+    let subDirectoryURL = URL(
+      fileURLWithPath: fileManager.currentDirectoryPath
+        .appending("/directory")
+    )
+
+    // Create subdirectory
+    try fileManager.createDirectory(atPath: subDirectoryURL.path)
+
+    // Then
+    let relativeURL = URL(string: "directory")!
+    XCTAssertFalse(try relativeURL.isLocalDirectoryContainingPackageDotSwift())
+
+    // Clean up subdirectory
+    if fileManager.fileExists(atPath: subDirectoryURL.path) {
+      try fileManager.removeItem(atPath: subDirectoryURL.path)
     }
+  }
 
-    private var fileManager: FileManager! = .default
-    private lazy var temporaryTestDirectoryPath: String = fileManager.currentDirectoryPath.appending("/TemporaryTest")
-    private lazy var temporaryTestDirectoryURL: URL = URL(fileURLWithPath: temporaryTestDirectoryPath)
-    private lazy var defaultTestFileURL: URL = makeTestFileURL()
+  func testIsValidLocalDirectoryWhenContainsPackageDotSwift() throws {
+    let subDirectoryURL = URL(
+      fileURLWithPath: fileManager.currentDirectoryPath
+        .appending("/directory")
+    )
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // Create a subdirectory
+    try fileManager.createDirectory(atPath: subDirectoryURL.path)
 
-        try fileManager.createDirectory(atPath: temporaryTestDirectoryPath)
+    // Create a Package.swift file on it
+    try fileManager.createFile(
+      atPath: subDirectoryURL.path + "/Package.swift",
+      content: "some-data".data(using: .utf8)!
+    )
+
+    // Then
+    let relativeURL = URL(string: "directory")!
+    XCTAssertTrue(try relativeURL.isLocalDirectoryContainingPackageDotSwift())
+
+    // Clean up subdirectory
+    if fileManager.fileExists(atPath: subDirectoryURL.path) {
+      try fileManager.removeItem(atPath: subDirectoryURL.path)
     }
+  }
 
-    override func tearDownWithError() throws {
-        try fileManager.removeItem(atPath: temporaryTestDirectoryPath)
-        fileManager = nil
+  // MARK: Tests - isValidRemote
 
-        try super.tearDownWithError()
-    }
+  func testIsValidRemote() throws {
+    var url = try XCTUnwrap(
+      URL(string: "https://www.bla.bla")
+    )
+    XCTAssertTrue(url.isValidRemote)
 
-    func testByteCountFormatter() {
-        let sut = URL.fileByteCountFormatter
-        XCTAssertEqual(sut.countStyle, .file)
-    }
+    url = try XCTUnwrap(
+      URL(string: "http://bla.bla")
+    )
+    XCTAssertTrue(url.isValidRemote)
 
-    func testTotalFileAllocatedSize() throws {
-        try createTestFile(atPath: defaultTestFileURL.path)
+    url = try XCTUnwrap(
+      URL(string: "htt://bla.bla")
+    )
+    XCTAssertFalse(url.isValidRemote)
 
-        XCTAssertEqual(try defaultTestFileURL.totalFileAllocatedSize(), 4096)
-    }
-
-    func testIsDirectoryForFile() throws {
-        try createTestFile(atPath: defaultTestFileURL.path)
-
-        XCTAssertFalse(try defaultTestFileURL.isDirectory())
-    }
-
-    func testIsDirectoryForDirectory() throws {
-        XCTAssertTrue(try temporaryTestDirectoryURL.isDirectory())
-    }
-
-    func testDirectoryTotalAllocatedSizeIncludingSubfolders() throws {
-        // create a file
-        try createTestFile(atPath: defaultTestFileURL.path)
-
-        // then
-        XCTAssertEqual(
-            try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: true),
-            4096
-        )
-
-        // create a subfolder
-        let subDirectoryURL = URL(
-            fileURLWithPath: temporaryTestDirectoryPath
-                .appending("/Subdirectory")
-        )
-        try fileManager.createDirectory(atPath: subDirectoryURL.path)
-
-        // Add a file to the subfolder
-        try createTestFile(
-            atPath: makeTestFileURL(directoryURL: subDirectoryURL, componentName: TestFile.file1.rawValue).path,
-            content: String(repeating: "1", count: 5_000).data(using: .utf8)!
-        )
-
-        // create another file to the main folder
-        try createTestFile(
-            atPath: makeTestFileURL(componentName: TestFile.file1.rawValue).path,
-            content: String(repeating: "1", count: 5_000).data(using: .utf8)!
-        )
-
-        // then
-        XCTAssertEqual(
-            try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: true),
-            20480
-        )
-    }
-
-    func testDirectoryTotalAllocatedSizeWithoutIncludingSubfolders() throws {
-        // create a file
-        try createTestFile(atPath: defaultTestFileURL.path)
-
-        // then
-        XCTAssertEqual(
-            try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: false),
-            4096
-        )
-
-        // create a subfolder
-        let subDirectoryURL = URL(
-            fileURLWithPath: temporaryTestDirectoryPath
-                .appending("/Subdirectory")
-        )
-        try fileManager.createDirectory(atPath: subDirectoryURL.path)
-
-        // Add a file to the subfolder
-        try createTestFile(
-            atPath: makeTestFileURL(directoryURL: subDirectoryURL, componentName: TestFile.file1.rawValue).path,
-            content: String(repeating: "1", count: 5_000).data(using: .utf8)!
-        )
-
-        // create another file to the main folder
-        try createTestFile(
-            atPath: makeTestFileURL(componentName: TestFile.file1.rawValue).path,
-            content: String(repeating: "1", count: 5_000).data(using: .utf8)!
-        )
-
-        // then
-        XCTAssertEqual(
-            try temporaryTestDirectoryURL.directoryTotalAllocatedSize(includingSubfolders: false),
-            12288
-        )
-    }
-
-    func testSizeOnDiskForFile() throws {
-        try createTestFile(atPath: defaultTestFileURL.path)
-
-        XCTAssertEqual(
-            try defaultTestFileURL.sizeOnDisk(),
-            .init(amount: 4096, formatted: "4 KB")
-        )
-    }
-
-    func testSizeOnDiskForDirectory() throws {
-        // Check initial directory size
-        XCTAssertEqual(
-            try temporaryTestDirectoryURL.sizeOnDisk(),
-            .init(amount: 0, formatted: "Zero KB")
-        )
-
-        // Create a new file in temporaryDirectory
-        try createTestFile(
-            atPath: defaultTestFileURL.path,
-            content: String(repeating: "1", count: 500_000).data(using: .utf8)!
-        )
-
-        // Then
-        XCTAssertEqual(
-            try temporaryTestDirectoryURL.sizeOnDisk(),
-            .init(amount: 503808, formatted: "504 KB")
-        )
-    }
-
-    // MARK: Tests - isValidLocalDirectory
-
-    func testIsValidLocalDirectoryWhenDoesNotContainPackageDotSwift() throws {
-        let subDirectoryURL = URL(
-            fileURLWithPath: fileManager.currentDirectoryPath
-                .appending("/directory")
-        )
-
-        // Create subdirectory
-        try fileManager.createDirectory(atPath: subDirectoryURL.path)
-
-        // Then
-        let relativeURL = URL(string: "directory")!
-        XCTAssertFalse(try relativeURL.isLocalDirectoryContainingPackageDotSwift())
-
-        // Clean up subdirectory
-        if fileManager.fileExists(atPath: subDirectoryURL.path) {
-            try fileManager.removeItem(atPath: subDirectoryURL.path)
-        }
-    }
-
-    func testIsValidLocalDirectoryWhenContainsPackageDotSwift() throws {
-        let subDirectoryURL = URL(
-            fileURLWithPath: fileManager.currentDirectoryPath
-                .appending("/directory")
-        )
-
-        // Create a subdirectory
-        try fileManager.createDirectory(atPath: subDirectoryURL.path)
-
-        // Create a Package.swift file on it
-        try fileManager.createFile(
-            atPath: subDirectoryURL.path + "/Package.swift",
-            content: "some-data".data(using: .utf8)!
-        )
-
-        // Then
-        let relativeURL = URL(string: "directory")!
-        XCTAssertTrue(try relativeURL.isLocalDirectoryContainingPackageDotSwift())
-
-        // Clean up subdirectory
-        if fileManager.fileExists(atPath: subDirectoryURL.path) {
-            try fileManager.removeItem(atPath: subDirectoryURL.path)
-        }
-    }
-
-    // MARK: Tests - isValidRemote
-
-    func testIsValidRemote() throws {
-        var url = try XCTUnwrap(
-            URL(string: "https://www.bla.bla")
-        )
-        XCTAssertTrue(url.isValidRemote)
-
-        url = try XCTUnwrap(
-            URL(string: "http://bla.bla")
-        )
-        XCTAssertTrue(url.isValidRemote)
-
-        url = try XCTUnwrap(
-            URL(string: "htt://bla.bla")
-        )
-        XCTAssertFalse(url.isValidRemote)
-
-        url = try XCTUnwrap(
-            URL(string: "https://bla")
-        )
-        XCTAssertFalse(url.isValidRemote)
-    }
+    url = try XCTUnwrap(
+      URL(string: "https://bla")
+    )
+    XCTAssertFalse(url.isValidRemote)
+  }
 }
 
 // MARK: - Helpers
 
 private extension URLExtensionTests {
-    func makeTestFileURL(
-        componentName: String = TestFile.file.rawValue
-    ) -> URL {
-        temporaryTestDirectoryURL
-            .appendingPathComponent(componentName)
-            .appendingPathExtension("txt")
-    }
+  func makeTestFileURL(
+    componentName: String = TestFile.file.rawValue
+  ) -> URL {
+    temporaryTestDirectoryURL
+      .appendingPathComponent(componentName)
+      .appendingPathExtension("txt")
+  }
 
-    func makeTestFileURL(
-        directoryURL: URL,
-        componentName: String = TestFile.file.rawValue
-    ) -> URL {
-        directoryURL
-            .appendingPathComponent(componentName)
-            .appendingPathExtension("txt")
-    }
+  func makeTestFileURL(
+    directoryURL: URL,
+    componentName: String = TestFile.file.rawValue
+  ) -> URL {
+    directoryURL
+      .appendingPathComponent(componentName)
+      .appendingPathExtension("txt")
+  }
 
-    func createTestFile(
-        atPath path: String,
-        content fakeData: Data = String(repeating: "1", count: 1_000).data(using: .utf8)!
-    ) throws {
-        try fileManager.createFile(atPath: path, content: fakeData)
-    }
+  func createTestFile(
+    atPath path: String,
+    content fakeData: Data = String(repeating: "1", count: 1_000).data(using: .utf8)!
+  ) throws {
+    try fileManager.createFile(atPath: path, content: fakeData)
+  }
 }

--- a/Tests/ReportsTests/Generators/ConsoleReportGeneratorTests.swift
+++ b/Tests/ReportsTests/Generators/ConsoleReportGeneratorTests.swift
@@ -24,135 +24,136 @@ import CoreTestSupport
 @testable import Core
 @testable import Reports
 
+@MainActor
 final class ConsoleReportGeneratorTests: XCTestCase {
-    func testRenderReport() {
-        let terminalControllerMock = TerminalControllerMock()
-        let progressAnimationMock = ProgressAnimationMock()
-
-        Console.default = Console(
-            isOutputColored: false,
-            terminalController: terminalControllerMock,
-            progressAnimation: progressAnimationMock
+  func testRenderReport() {
+    let terminalControllerMock = TerminalControllerMock()
+    let progressAnimationMock = ProgressAnimationMock()
+    
+    Console.default = Console(
+      isOutputColored: false,
+      terminalController: terminalControllerMock,
+      progressAnimation: progressAnimationMock
+    )
+    
+    let sut = ConsoleReportGenerator(
+      console: .default
+    )
+    
+    sut.renderReport(
+      for: Fixture.makeSwiftPackage(),
+      providedInfos: [
+        ProvidedInfo.init(
+          providerName: "Name",
+          providerKind: .binarySize,
+          information: Fixture.makeProvidedInfoInformation()
         )
-
-        let sut = ConsoleReportGenerator(
-            console: .default
-        )
-
-        sut.renderReport(
-            for: Fixture.makeSwiftPackage(),
-            providedInfos: [
-                ProvidedInfo.init(
-                    providerName: "Name",
-                    providerKind: .binarySize,
-                    information: Fixture.makeProvidedInfoInformation()
-                )
-            ]
-        )
-
-        XCTAssertEqual(progressAnimationMock.completeCallsCount, 0)
-        XCTAssertEqual(progressAnimationMock.clearCallsCount, 0)
-        XCTAssertEqual(progressAnimationMock.updateCallsCount, 0)
-
-        XCTAssertEqual(terminalControllerMock.writeCallsCount, 39)
-        XCTAssertEqual(terminalControllerMock.endLineCallsCount, 13)
-
-        XCTAssertEqual(
-            terminalControllerMock.writeStrings,
-            [
-                "+----------------------------+",
-                "|",
-                "     ",
-                "Swift Package Info",
-                "     ",
-                "|",
-                "|",
-                "                            ",
-                "|",
-                "|",
-                "         ",
-                "Some, 1.0.0",
-                "        ",
-                "|",
-                "+----------+-----------------+",
-                "|",
-                " ",
-                "Provider",
-                " ",
-                "|",
-                " ",
-                "Results",
-                "         ",
-                "|",
-                "+----------+-----------------+",
-                "|",
-                " ",
-                "Name",
-                "     ",
-                "|",
-                " ",
-                "name",
-                "Value is 10",
-                " ",
-                "|",
-                "+----------+-----------------+",
-                "> Total of ",
-                "1",
-                " provider used."
-            ]
-        )
-
-        XCTAssertEqual(
-            terminalControllerMock.writeColors.count,
-            39
-        )
-        XCTAssertEqual(
-            Set(terminalControllerMock.writeColors),
-            Set([.noColor])
-        )
-        XCTAssertEqual(
-            terminalControllerMock.writeBolds,
-            [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false
-            ]
-        )
-    }
+      ]
+    )
+    
+    XCTAssertEqual(progressAnimationMock.completeCallsCount, 0)
+    XCTAssertEqual(progressAnimationMock.clearCallsCount, 0)
+    XCTAssertEqual(progressAnimationMock.updateCallsCount, 0)
+    
+    XCTAssertEqual(terminalControllerMock.writeCallsCount, 39)
+    XCTAssertEqual(terminalControllerMock.endLineCallsCount, 13)
+    
+    XCTAssertEqual(
+      terminalControllerMock.writeStrings,
+      [
+        "+----------------------------+",
+        "|",
+        "     ",
+        "Swift Package Info",
+        "     ",
+        "|",
+        "|",
+        "                            ",
+        "|",
+        "|",
+        "         ",
+        "Some, 1.0.0",
+        "        ",
+        "|",
+        "+----------+-----------------+",
+        "|",
+        " ",
+        "Provider",
+        " ",
+        "|",
+        " ",
+        "Results",
+        "         ",
+        "|",
+        "+----------+-----------------+",
+        "|",
+        " ",
+        "Name",
+        "     ",
+        "|",
+        " ",
+        "name",
+        "Value is 10",
+        " ",
+        "|",
+        "+----------+-----------------+",
+        "> Total of ",
+        "1",
+        " provider used."
+      ]
+    )
+    
+    XCTAssertEqual(
+      terminalControllerMock.writeColors.count,
+      39
+    )
+    XCTAssertEqual(
+      Set(terminalControllerMock.writeColors),
+      Set([.noColor])
+    )
+    XCTAssertEqual(
+      terminalControllerMock.writeBolds,
+      [
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false
+      ]
+    )
+  }
 }


### PR DESCRIPTION
As says the title, `swift-package-info` is now async await first and Swift strict concurrency compliant.

This is a step before library version is added.

On the way the minimum required Swift version was updated from `5.7` to `5.8`.