### PR TITLE
Clone Empty App from latest stable release

### DIFF
--- a/MeasurementApp/MeasurementApp.swift
+++ b/MeasurementApp/MeasurementApp.swift
@@ -22,9 +22,9 @@ import SwiftUI
 
 @main
 struct MeasurementAppApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
     }
+  }
 }

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -79,7 +79,7 @@ final class AppManager {
       try await Shell.performShallowGitClone(
         workingDirectory: fileManager.currentDirectoryPath,
         repositoryURLString: "https://github.com/marinofelipe/swift-package-info",
-        branchOrTag: "1.5.0",
+        branchOrTag: "1.5.0", // latest stable release to avoid issues while developing on the main branch
         verbose: verbose
       )
     } catch {

--- a/Sources/App/Providers/BinarySizeProvider/AppManager.swift
+++ b/Sources/App/Providers/BinarySizeProvider/AppManager.swift
@@ -79,7 +79,7 @@ final class AppManager {
       try await Shell.performShallowGitClone(
         workingDirectory: fileManager.currentDirectoryPath,
         repositoryURLString: "https://github.com/marinofelipe/swift-package-info",
-        branchOrTag: "main",
+        branchOrTag: "1.5.0",
         verbose: verbose
       )
     } catch {


### PR DESCRIPTION
This is to avoid issues in the future similar to #55, where changing the EmptyApp Xcodeproj on the main branch broke the archiving with the dependency added.